### PR TITLE
Expose operationId in server, client, and hono packages

### DIFF
--- a/.changeset/tasty-cameras-itch.md
+++ b/.changeset/tasty-cameras-itch.md
@@ -1,0 +1,14 @@
+---
+"@rexeus/typeweaver-clients": minor
+"@rexeus/typeweaver-server": minor
+"@rexeus/typeweaver-types": minor
+"@rexeus/typeweaver-hono": minor
+"@rexeus/typeweaver": minor
+---
+
+- Expose operationId from API definitions at runtime.
+  - The operationId defined in OpenAPI specs is now available across all runtime layers:
+    server middleware and handlers via `ctx.route.operationId`, client request commands
+    via `this.operationId`, and Hono route handlers through the middleware context.
+  - This enables logging, tracing, and metrics keyed to the original API operation without
+    hardcoding strings.

--- a/.changeset/tasty-cameras-itch.md
+++ b/.changeset/tasty-cameras-itch.md
@@ -7,8 +7,13 @@
 ---
 
 - Expose operationId from API definitions at runtime.
-  - The operationId defined in OpenAPI specs is now available across all runtime layers:
-    server middleware and handlers via `ctx.route.operationId`, client request commands
-    via `this.operationId`, and Hono route handlers through the middleware context.
+  - The operationId defined in OpenAPI specs is now available across all runtime layers: server
+    middleware and handlers via `ctx.route.operationId`, client request commands via
+    `this.operationId`, and Hono route handlers through the middleware context.
   - This enables logging, tracing, and metrics keyed to the original API operation without
     hardcoding strings.
+- Simplify response class constructors.
+  - Response constructors no longer accept `statusCode` — each class hard-codes its own status code
+    via a direct property initializer. The constructor parameter type changes from `I…Response` to
+    `Omit<I…Response, "statusCode">`. Responses without header or body use a zero-arg constructor.
+  - Fix ResponseValidator to call the zero-arg constructor for empty responses.

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -15,6 +15,7 @@ jobs:
   quality-check:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -40,6 +40,7 @@
   "ignorePatterns": [
     "node_modules",
     "dist",
+    ".changeset",
     "pnpm-lock.yaml",
     "coverage",
     "*.log",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,7 +10,6 @@
   This prevents tsc from hitting OOM on Zod v4's deeply recursive type inference. The generated
   `.d.ts` stubs use `any` internally — the public API remains fully typed through the validator and
   consumer layers.
-
   - @rexeus/typeweaver-aws-cdk@0.6.5
   - @rexeus/typeweaver-clients@0.6.5
   - @rexeus/typeweaver-core@0.6.5
@@ -69,7 +68,6 @@
 ### Patch Changes
 
 - edd224c: Fix generated code issues and stabilize CLI binary resolution
-
   - Fix trailing comma in Response.ejs template that produced `HttpResponse<Header, Body,>` in
     generated response classes
   - Widen `TypeweaverRouter` generic constraint from `RequestHandler` to

--- a/packages/clients/__test__/unit/ApiClient.test.ts
+++ b/packages/clients/__test__/unit/ApiClient.test.ts
@@ -10,6 +10,8 @@ import {
   ListTodosRequestCommand,
   NetworkError,
   PathParameterError,
+  PutTodoRequestCommand,
+  createPutTodoRequest,
   ResponseParseError,
   TodoClient,
 } from "test-utils";
@@ -52,6 +54,24 @@ function createPassthroughClient(mockFetch: typeof globalThis.fetch) {
     isSuccessStatusCode: () => true,
   });
 }
+
+describe("RequestCommand operationId", () => {
+  test("should expose operationId from the API definition", () => {
+    const command = new ListTodosRequestCommand(createListTodosRequest());
+
+    expect(command.operationId).toBe("ListTodos");
+  });
+
+  test("should expose correct operationId for different commands", () => {
+    const get = new GetTodoRequestCommand(createGetTodoRequest());
+    const create = new CreateTodoRequestCommand(createCreateTodoRequest());
+    const put = new PutTodoRequestCommand(createPutTodoRequest());
+
+    expect(get.operationId).toBe("GetTodo");
+    expect(create.operationId).toBe("CreateTodo");
+    expect(put.operationId).toBe("PutTodo");
+  });
+});
 
 describe("ApiClient URL Construction", () => {
   function createCommand(todoId: string) {

--- a/packages/clients/src/lib/RequestCommand.ts
+++ b/packages/clients/src/lib/RequestCommand.ts
@@ -48,6 +48,8 @@ export abstract class RequestCommand<
   Query extends IHttpQuery = IHttpQuery | undefined,
   Body extends IHttpBody = IHttpBody | undefined,
 > implements IHttpRequest {
+  /** Unique operation identifier from the API definition */
+  public readonly operationId!: string;
   /** The HTTP method for this request */
   public readonly method!: HttpMethod;
   /** The URL path pattern with parameter placeholders (e.g., '/users/:id') */

--- a/packages/clients/src/templates/RequestCommand.ejs
+++ b/packages/clients/src/templates/RequestCommand.ejs
@@ -23,6 +23,7 @@ import { <%= successResponse.name %>Response } from "<%= successResponseImportPa
 <% } %>
 
 export class <%= pascalCaseOperationId %>RequestCommand extends RequestCommand implements I<%= pascalCaseOperationId %>Request {
+    public override readonly operationId = definition.operationId;
     public override readonly method = definition.method as HttpMethod.<%= method %>;
     public override readonly path = definition.path;
 

--- a/packages/hono/__test__/unit/generated/GeneratedHono.test.ts
+++ b/packages/hono/__test__/unit/generated/GeneratedHono.test.ts
@@ -12,7 +12,10 @@ import {
   TodoHono,
 } from "test-utils";
 import { describe, expect, test } from "vitest";
-import type { HonoTodoApiHandler, IValidationErrorResponseBody } from "test-utils";
+import type {
+  HonoTodoApiHandler,
+  IValidationErrorResponseBody,
+} from "test-utils";
 
 function prepareRequestData(requestData: IHttpRequest): RequestInit {
   const body =
@@ -469,11 +472,10 @@ describe("Generated Hono Router", () => {
       const capturedIds: string[] = [];
 
       const stubHandlers = new Proxy({} as HonoTodoApiHandler, {
-        get: () =>
-          async (_req: any, context: any) => {
-            capturedIds.push(context.get("operationId"));
-            return { statusCode: 200, body: {} };
-          },
+        get: () => async (_req: any, context: any) => {
+          capturedIds.push(context.get("operationId"));
+          return { statusCode: 200, body: {} };
+        },
       });
 
       const app = new TodoHono({

--- a/packages/hono/__test__/unit/generated/GeneratedHono.test.ts
+++ b/packages/hono/__test__/unit/generated/GeneratedHono.test.ts
@@ -9,9 +9,10 @@ import {
   createTestHono,
   createUpdateTodoRequest,
   createUpdateTodoStatusRequest,
+  TodoHono,
 } from "test-utils";
 import { describe, expect, test } from "vitest";
-import type { IValidationErrorResponseBody } from "test-utils";
+import type { HonoTodoApiHandler, IValidationErrorResponseBody } from "test-utils";
 
 function prepareRequestData(requestData: IHttpRequest): RequestInit {
   const body =
@@ -432,6 +433,59 @@ describe("Generated Hono Router", () => {
       const allowHeader = response.headers.get("Allow");
       expect(allowHeader).toBeDefined();
       expect(allowHeader).toBe("GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS");
+    });
+  });
+
+  describe("Route Metadata (operationId)", () => {
+    test("should set operationId on Hono context before handler runs", async () => {
+      let capturedOperationId: string | undefined;
+
+      const stubHandlers = new Proxy({} as HonoTodoApiHandler, {
+        get: (_target, prop) => {
+          if (prop === "handleListTodosRequest") {
+            return async (_req: any, context: any) => {
+              capturedOperationId = context.get("operationId");
+              return { statusCode: 200, body: [] };
+            };
+          }
+          return async () => ({ statusCode: 200 });
+        },
+      });
+
+      const app = new TodoHono({
+        requestHandlers: stubHandlers,
+        validateRequests: false,
+      });
+
+      const response = await app.request("http://localhost/todos?status=TODO", {
+        method: "GET",
+      });
+
+      expect(response.status).toBe(200);
+      expect(capturedOperationId).toBe("ListTodos");
+    });
+
+    test("should set different operationId per route", async () => {
+      const capturedIds: string[] = [];
+
+      const stubHandlers = new Proxy({} as HonoTodoApiHandler, {
+        get: () =>
+          async (_req: any, context: any) => {
+            capturedIds.push(context.get("operationId"));
+            return { statusCode: 200, body: {} };
+          },
+      });
+
+      const app = new TodoHono({
+        requestHandlers: stubHandlers,
+        validateRequests: false,
+      });
+
+      await app.request("http://localhost/todos", { method: "GET" });
+      await app.request("http://localhost/todos", { method: "POST" });
+      await app.request("http://localhost/todos/t1", { method: "GET" });
+
+      expect(capturedIds).toEqual(["ListTodos", "CreateTodo", "GetTodo"]);
     });
   });
 

--- a/packages/hono/src/HonoRouterGenerator.ts
+++ b/packages/hono/src/HonoRouterGenerator.ts
@@ -57,6 +57,7 @@ export class HonoRouterGenerator {
     const handlerName = `handle${className}Request`;
 
     return {
+      operationId,
       className,
       handlerName,
       method: resource.definition.method,

--- a/packages/hono/src/lib/TypeweaverHono.ts
+++ b/packages/hono/src/lib/TypeweaverHono.ts
@@ -303,6 +303,7 @@ export abstract class TypeweaverHono<
    * Handles a request with validation and type-safe response conversion.
    *
    * @param context - Hono context for the current request
+   * @param operationId - Unique operation identifier from the API definition
    * @param validator - Request validator for the specific operation
    * @param handler - Type-safe request handler function
    * @returns Hono-compatible Response object
@@ -312,10 +313,13 @@ export abstract class TypeweaverHono<
     TResponse extends IHttpResponse,
   >(
     context: Context,
+    operationId: string,
     validator: IRequestValidator,
     handler: HonoRequestHandler<TRequest, TResponse>
   ): Promise<Response> {
     try {
+      context.set("operationId", operationId);
+
       const httpRequest = await this.adapter.toRequest(context);
 
       // Conditionally validate

--- a/packages/hono/src/templates/HonoRouter.ejs
+++ b/packages/hono/src/templates/HonoRouter.ejs
@@ -31,6 +31,7 @@ export class <%- pascalCaseEntityName %>Hono extends TypeweaverHono<Hono<%- pasc
     this.<%- operation.method.toLowerCase() %>('<%- operation.path %>', async (context: Context) =>
       this.handleRequest(
         context,
+        '<%- operation.operationId %>',
         new <%- operation.className %>RequestValidator(),
         this.requestHandlers.<%- operation.handlerName %>.bind(this.requestHandlers)
       ));

--- a/packages/server/__test__/helpers.ts
+++ b/packages/server/__test__/helpers.ts
@@ -30,6 +30,7 @@ export function createServerContext(
       ...(overrides.query ? { query: overrides.query } : {}),
     },
     state: new StateMap(),
+    route: undefined,
   };
 }
 

--- a/packages/server/__test__/unit/Router.test.ts
+++ b/packages/server/__test__/unit/Router.test.ts
@@ -17,6 +17,7 @@ function createRoute(
   id?: string
 ): RouteDefinition {
   return {
+    operationId: id ?? `${method.toLowerCase()}${path.replace(/[/:]/g, "_")}`,
     method: method.toUpperCase() as HttpMethod,
     path,
     validator: noopValidator,

--- a/packages/server/__test__/unit/RouterGenerator.test.ts
+++ b/packages/server/__test__/unit/RouterGenerator.test.ts
@@ -71,6 +71,7 @@ function createMockContext(operations: OperationResource[]): {
       // Return operations in order so we can verify sorting
       return JSON.stringify(
         data.operations.map((op: any) => ({
+          operationId: op.operationId,
           method: op.method,
           path: op.path,
           handlerName: op.handlerName,
@@ -89,7 +90,7 @@ function createMockContext(operations: OperationResource[]): {
 
 function getOperationOrder(
   operations: OperationResource[]
-): { method: string; path: string; handlerName: string; className: string }[] {
+): { operationId: string; method: string; path: string; handlerName: string; className: string }[] {
   const { context, writtenFiles } = createMockContext(operations);
   RouterGenerator.generate(context);
 

--- a/packages/server/__test__/unit/RouterGenerator.test.ts
+++ b/packages/server/__test__/unit/RouterGenerator.test.ts
@@ -88,9 +88,13 @@ function createMockContext(operations: OperationResource[]): {
   return { context, writtenFiles };
 }
 
-function getOperationOrder(
-  operations: OperationResource[]
-): { operationId: string; method: string; path: string; handlerName: string; className: string }[] {
+function getOperationOrder(operations: OperationResource[]): {
+  operationId: string;
+  method: string;
+  path: string;
+  handlerName: string;
+  className: string;
+}[] {
   const { context, writtenFiles } = createMockContext(operations);
   RouterGenerator.generate(context);
 

--- a/packages/server/__test__/unit/TypedMiddleware.test.ts
+++ b/packages/server/__test__/unit/TypedMiddleware.test.ts
@@ -81,7 +81,7 @@ describe("TypedMiddleware", () => {
       class TestRouter extends TypeweaverRouter<Handlers> {
         public constructor(options: any) {
           super(options);
-          this.route(HttpMethod.GET, "/test", noopValidator, async (req, ctx) =>
+          this.route("getTest", HttpMethod.GET, "/test", noopValidator, async (req, ctx) =>
             this.requestHandlers.handleGet(req, ctx)
           );
         }

--- a/packages/server/__test__/unit/TypedMiddleware.test.ts
+++ b/packages/server/__test__/unit/TypedMiddleware.test.ts
@@ -81,8 +81,12 @@ describe("TypedMiddleware", () => {
       class TestRouter extends TypeweaverRouter<Handlers> {
         public constructor(options: any) {
           super(options);
-          this.route("getTest", HttpMethod.GET, "/test", noopValidator, async (req, ctx) =>
-            this.requestHandlers.handleGet(req, ctx)
+          this.route(
+            "getTest",
+            HttpMethod.GET,
+            "/test",
+            noopValidator,
+            async (req, ctx) => this.requestHandlers.handleGet(req, ctx)
           );
         }
       }

--- a/packages/server/__test__/unit/TypeweaverApp.test.ts
+++ b/packages/server/__test__/unit/TypeweaverApp.test.ts
@@ -69,6 +69,7 @@ class TestRouter extends TypeweaverRouter<TestHandlers> {
     super(options);
 
     this.route(
+      "listTodos",
       HttpMethod.GET,
       "/todos",
       options.validateRequests === false ? noopValidator : failingValidator,
@@ -76,6 +77,7 @@ class TestRouter extends TypeweaverRouter<TestHandlers> {
     );
 
     this.route(
+      "createTodo",
       HttpMethod.POST,
       "/todos",
       options.validateRequests === false ? noopValidator : failingValidator,
@@ -83,6 +85,7 @@ class TestRouter extends TypeweaverRouter<TestHandlers> {
     );
 
     this.route(
+      "getTodo",
       HttpMethod.GET,
       "/todos/:todoId",
       options.validateRequests === false ? noopValidator : failingValidator,
@@ -95,8 +98,12 @@ class ValidatingTestRouter extends TypeweaverRouter<TestHandlers> {
   constructor(options: TypeweaverRouterOptions<TestHandlers>) {
     super(options);
 
-    this.route(HttpMethod.POST, "/todos", failingValidator, async (req, ctx) =>
-      this.requestHandlers.handleCreateTodo(req, ctx)
+    this.route(
+      "createTodo",
+      HttpMethod.POST,
+      "/todos",
+      failingValidator,
+      async (req, ctx) => this.requestHandlers.handleCreateTodo(req, ctx)
     );
   }
 }
@@ -106,6 +113,7 @@ class BodyOnlyValidatingRouter extends TypeweaverRouter<TestHandlers> {
     super(options);
 
     this.route(
+      "createTodo",
       HttpMethod.POST,
       "/todos",
       bodyOnlyFailingValidator,
@@ -503,6 +511,7 @@ describe("TypeweaverApp", () => {
         constructor(options: TypeweaverRouterOptions<UserHandlers>) {
           super(options);
           this.route(
+            "listUsers",
             HttpMethod.GET,
             "/users",
             noopValidator,
@@ -1189,6 +1198,91 @@ describe("TypeweaverApp", () => {
 
       await expectErrorResponse(res, 500, "INTERNAL_SERVER_ERROR");
       expect(onError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("Route Metadata (operationId)", () => {
+    test("should expose route metadata to middleware via ctx.route", async () => {
+      let capturedRoute: unknown;
+      const spy = defineMiddleware(async (ctx, next) => {
+        capturedRoute = ctx.route;
+        return next();
+      });
+
+      const app = createApp();
+      app.use(spy);
+
+      await app.fetch(get("/todos"));
+
+      expect(capturedRoute).toEqual({
+        operationId: "listTodos",
+        method: "GET",
+        path: "/todos",
+      });
+    });
+
+    test("should expose route metadata to request handler via ctx.route", async () => {
+      const app = createApp(undefined, {
+        handleGetTodos: async (_req, ctx) => ({
+          statusCode: 200,
+          body: { route: ctx.route },
+        }),
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      const data = await expectJson(res, 200);
+      expect(data.route).toEqual({
+        operationId: "listTodos",
+        method: "GET",
+        path: "/todos",
+      });
+    });
+
+    test("should expose correct operationId for parameterized routes", async () => {
+      const app = createApp(undefined, {
+        handleGetTodo: async (_req, ctx) => ({
+          statusCode: 200,
+          body: { operationId: ctx.route?.operationId },
+        }),
+      });
+
+      const res = await app.fetch(get("/todos/todo-42"));
+
+      const data = await expectJson(res, 200);
+      expect(data.operationId).toBe("getTodo");
+    });
+
+    test("should set ctx.route to undefined for 404 requests", async () => {
+      let capturedRoute: unknown = "not-set";
+      const spy = defineMiddleware(async (ctx, next) => {
+        capturedRoute = ctx.route;
+        return next();
+      });
+
+      const app = createApp();
+      app.use(spy);
+
+      const res = await app.fetch(get("/nonexistent"));
+
+      expect(res.status).toBe(404);
+      expect(capturedRoute).toBeUndefined();
+    });
+
+    test("should set ctx.route to undefined for 405 requests", async () => {
+      let capturedRoute: unknown = "not-set";
+      const spy = defineMiddleware(async (ctx, next) => {
+        capturedRoute = ctx.route;
+        return next();
+      });
+
+      const app = createApp();
+      app.use(spy);
+
+      const res = await app.fetch(del("/todos"));
+
+      expect(res.status).toBe(405);
+      expect(capturedRoute).toBeUndefined();
     });
   });
 

--- a/packages/server/__test__/unit/generated/GeneratedServer.test.ts
+++ b/packages/server/__test__/unit/generated/GeneratedServer.test.ts
@@ -147,6 +147,40 @@ describe("Generated Server Router", () => {
     });
   });
 
+  describe("Route Metadata (operationId)", () => {
+    test("should expose operationId to middleware via ctx.route", async () => {
+      let capturedOperationId: string | undefined;
+      const spy = defineMiddleware(async (ctx, next) => {
+        capturedOperationId = ctx.route?.operationId;
+        return next();
+      });
+
+      const app = createTestApp();
+      app.use(spy);
+
+      await app.fetch(
+        buildFetchRequest(`${BASE_URL}/todos?status=TODO`, createListTodosRequest())
+      );
+
+      expect(capturedOperationId).toBe("ListTodos");
+    });
+
+    test("should set ctx.route to undefined for unmatched paths", async () => {
+      let capturedRoute: unknown = "not-set";
+      const spy = defineMiddleware(async (ctx, next) => {
+        capturedRoute = ctx.route;
+        return next();
+      });
+
+      const app = createTestApp();
+      app.use(spy);
+
+      await app.fetch(new Request(`${BASE_URL}/nonexistent`, { method: "GET" }));
+
+      expect(capturedRoute).toBeUndefined();
+    });
+  });
+
   describe("Request Validation", () => {
     test.each([
       {

--- a/packages/server/__test__/unit/generated/GeneratedServer.test.ts
+++ b/packages/server/__test__/unit/generated/GeneratedServer.test.ts
@@ -159,7 +159,10 @@ describe("Generated Server Router", () => {
       app.use(spy);
 
       await app.fetch(
-        buildFetchRequest(`${BASE_URL}/todos?status=TODO`, createListTodosRequest())
+        buildFetchRequest(
+          `${BASE_URL}/todos?status=TODO`,
+          createListTodosRequest()
+        )
       );
 
       expect(capturedOperationId).toBe("ListTodos");
@@ -175,7 +178,9 @@ describe("Generated Server Router", () => {
       const app = createTestApp();
       app.use(spy);
 
-      await app.fetch(new Request(`${BASE_URL}/nonexistent`, { method: "GET" }));
+      await app.fetch(
+        new Request(`${BASE_URL}/nonexistent`, { method: "GET" })
+      );
 
       expect(capturedRoute).toBeUndefined();
     });

--- a/packages/server/src/RouterGenerator.ts
+++ b/packages/server/src/RouterGenerator.ts
@@ -9,6 +9,7 @@ import type {
 import Case from "case";
 
 type OperationData = {
+  readonly operationId: string;
   readonly className: string;
   readonly handlerName: string;
   readonly method: string;
@@ -72,9 +73,11 @@ export class RouterGenerator {
   private static createOperationData(
     resource: OperationResource
   ): OperationData {
-    const className = Case.pascal(resource.definition.operationId);
+    const operationId = resource.definition.operationId;
+    const className = Case.pascal(operationId);
 
     return {
+      operationId,
       className,
       handlerName: `handle${className}Request`,
       method: resource.definition.method,

--- a/packages/server/src/lib/Router.ts
+++ b/packages/server/src/lib/Router.ts
@@ -15,9 +15,19 @@ import type { RequestHandler } from "./RequestHandler";
 import type { ServerContext } from "./ServerContext";
 
 /**
+ * Metadata about a matched route, available in middleware and handlers via `ctx.route`.
+ */
+export type RouteMetadata = {
+  readonly operationId: string;
+  readonly method: HttpMethod;
+  readonly path: string;
+};
+
+/**
  * A registered route with its method, path pattern, validator, and handler.
  */
 export type RouteDefinition = {
+  readonly operationId: string;
   readonly method: HttpMethod;
   readonly path: string;
   readonly validator: IRequestValidator;

--- a/packages/server/src/lib/ServerContext.ts
+++ b/packages/server/src/lib/ServerContext.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IHttpRequest } from "@rexeus/typeweaver-core";
+import type { RouteMetadata } from "./Router";
 import type { StateMap } from "./StateMap";
 
 /**
@@ -51,4 +52,7 @@ export type ServerContext<
 
   /** Type-safe key-value store for sharing data between middleware and handlers. */
   readonly state: StateMap<TState>;
+
+  /** Metadata about the matched route, or `undefined` for 404/405 requests. */
+  readonly route: RouteMetadata | undefined;
 };

--- a/packages/server/src/lib/TypeweaverApp.ts
+++ b/packages/server/src/lib/TypeweaverApp.ts
@@ -17,6 +17,7 @@ import type { RequestHandler } from "./RequestHandler";
 import type {
   HttpResponseErrorHandler,
   RouteDefinition,
+  RouteMatch,
   UnknownErrorHandler,
   ValidationErrorHandler,
 } from "./Router";
@@ -186,15 +187,24 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
     const url = new URL(request.url);
     const httpRequest = await this.adapter.toRequest(request, url);
 
+    const match = this.router.match(request.method, url.pathname);
+
     const ctx: ServerContext = {
       request: httpRequest,
       state: new StateMap(),
+      route: match
+        ? {
+            operationId: match.route.operationId,
+            method: match.route.method,
+            path: match.route.path,
+          }
+        : undefined,
     };
 
     const response = await executeMiddlewarePipeline(
       this.middlewares,
       ctx,
-      () => this.resolveAndExecute(request.method, url.pathname, ctx)
+      () => this.resolveAndExecute(match, url.pathname, ctx)
     );
 
     return request.method.toUpperCase() === "HEAD"
@@ -203,16 +213,14 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
   }
 
   /**
-   * Match the route and execute the handler.
+   * Execute the matched route handler, or produce 404/405 responses.
    * Called as the final handler in the middleware pipeline.
    */
   private async resolveAndExecute(
-    method: string,
+    match: RouteMatch | undefined,
     pathname: string,
     ctx: ServerContext
   ): Promise<IHttpResponse> {
-    const match = this.router.match(method, pathname);
-
     if (match) {
       const routeCtx = this.withPathParams(ctx, match.params);
       try {

--- a/packages/server/src/lib/TypeweaverRouter.ts
+++ b/packages/server/src/lib/TypeweaverRouter.ts
@@ -109,18 +109,21 @@ export abstract class TypeweaverRouter<
   /**
    * Register a route. Called by generated subclasses in their constructor.
    *
+   * @param operationId - Unique operation identifier from the API definition
    * @param method - HTTP method (GET, POST, PUT, DELETE, etc.)
    * @param path - Path pattern with `:param` placeholders
    * @param validator - Request validator for this operation
    * @param handler - Type-safe request handler
    */
   protected route(
+    operationId: string,
     method: HttpMethod,
     path: string,
     validator: IRequestValidator,
     handler: RequestHandler<any, any, any>
   ): void {
     this.routes.push({
+      operationId,
       method,
       path,
       validator,

--- a/packages/server/src/lib/index.ts
+++ b/packages/server/src/lib/index.ts
@@ -15,6 +15,7 @@ export {
 export { HttpMethod } from "@rexeus/typeweaver-core";
 export type {
   HttpResponseErrorHandler,
+  RouteMetadata,
   UnknownErrorHandler,
   ValidationErrorHandler,
 } from "./Router";

--- a/packages/server/src/templates/Router.ejs
+++ b/packages/server/src/templates/Router.ejs
@@ -32,6 +32,7 @@ export class <%- pascalCaseEntityName %>Router<
   protected setupRoutes(): void {
 <% for (const operation of operations) { %>
     this.route(
+      '<%- operation.operationId %>',
       HttpMethod.<%- operation.method %>,
       '<%- operation.path %>',
       new <%- operation.className %>RequestValidator(),

--- a/packages/test-utils/src/test-project/output/account/AccountHono.ts
+++ b/packages/test-utils/src/test-project/output/account/AccountHono.ts
@@ -30,6 +30,7 @@ export class AccountHono extends TypeweaverHono<HonoAccountApiHandler> {
     this.post("/accounts", async (context: Context) =>
       this.handleRequest(
         context,
+        "RegisterAccount",
         new RegisterAccountRequestValidator(),
         this.requestHandlers.handleRegisterAccountRequest.bind(this.requestHandlers),
       ),

--- a/packages/test-utils/src/test-project/output/account/AccountRouter.ts
+++ b/packages/test-utils/src/test-project/output/account/AccountRouter.ts
@@ -37,6 +37,7 @@ export class AccountRouter<
 
   protected setupRoutes(): void {
     this.route(
+      "RegisterAccount",
       HttpMethod.POST,
       "/accounts",
       new RegisterAccountRequestValidator(),

--- a/packages/test-utils/src/test-project/output/account/RegisterAccountRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/account/RegisterAccountRequestCommand.ts
@@ -28,6 +28,7 @@ export class RegisterAccountRequestCommand
   extends RequestCommand
   implements IRegisterAccountRequest
 {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/account/RegisterAccountResponse.ts
+++ b/packages/test-utils/src/test-project/output/account/RegisterAccountResponse.ts
@@ -63,18 +63,10 @@ export class RegisterAccountSuccessResponse
   extends HttpResponse<IRegisterAccountSuccessResponseHeader, IRegisterAccountSuccessResponseBody>
   implements IRegisterAccountSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.CREATED;
+  public override readonly statusCode = HttpStatusCode.CREATED;
 
-  public constructor(response: IRegisterAccountSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CREATED) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for RegisterAccountSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IRegisterAccountSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.CREATED, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/auth/AccessTokenRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/auth/AccessTokenRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { AccessTokenSuccessResponse } from "./AccessTokenResponse";
 
 export class AccessTokenRequestCommand extends RequestCommand implements IAccessTokenRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/auth/AccessTokenResponse.ts
+++ b/packages/test-utils/src/test-project/output/auth/AccessTokenResponse.ts
@@ -59,18 +59,10 @@ export class AccessTokenSuccessResponse
   extends HttpResponse<IAccessTokenSuccessResponseHeader, IAccessTokenSuccessResponseBody>
   implements IAccessTokenSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IAccessTokenSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for AccessTokenSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IAccessTokenSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/auth/AuthHono.ts
+++ b/packages/test-utils/src/test-project/output/auth/AuthHono.ts
@@ -33,6 +33,7 @@ export class AuthHono extends TypeweaverHono<HonoAuthApiHandler> {
     this.post("/auth/access-token", async (context: Context) =>
       this.handleRequest(
         context,
+        "AccessToken",
         new AccessTokenRequestValidator(),
         this.requestHandlers.handleAccessTokenRequest.bind(this.requestHandlers),
       ),
@@ -41,6 +42,7 @@ export class AuthHono extends TypeweaverHono<HonoAuthApiHandler> {
     this.post("/auth/refresh-token", async (context: Context) =>
       this.handleRequest(
         context,
+        "RefreshToken",
         new RefreshTokenRequestValidator(),
         this.requestHandlers.handleRefreshTokenRequest.bind(this.requestHandlers),
       ),

--- a/packages/test-utils/src/test-project/output/auth/AuthRouter.ts
+++ b/packages/test-utils/src/test-project/output/auth/AuthRouter.ts
@@ -38,6 +38,7 @@ export class AuthRouter<
 
   protected setupRoutes(): void {
     this.route(
+      "AccessToken",
       HttpMethod.POST,
       "/auth/access-token",
       new AccessTokenRequestValidator(),
@@ -45,6 +46,7 @@ export class AuthRouter<
     );
 
     this.route(
+      "RefreshToken",
       HttpMethod.POST,
       "/auth/refresh-token",
       new RefreshTokenRequestValidator(),

--- a/packages/test-utils/src/test-project/output/auth/RefreshTokenRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/auth/RefreshTokenRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { RefreshTokenSuccessResponse } from "./RefreshTokenResponse";
 
 export class RefreshTokenRequestCommand extends RequestCommand implements IRefreshTokenRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/auth/RefreshTokenResponse.ts
+++ b/packages/test-utils/src/test-project/output/auth/RefreshTokenResponse.ts
@@ -59,18 +59,10 @@ export class RefreshTokenSuccessResponse
   extends HttpResponse<IRefreshTokenSuccessResponseHeader, IRefreshTokenSuccessResponseBody>
   implements IRefreshTokenSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IRefreshTokenSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for RefreshTokenSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IRefreshTokenSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/file/DownloadFileContentRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/file/DownloadFileContentRequestCommand.ts
@@ -28,6 +28,7 @@ export class DownloadFileContentRequestCommand
   extends RequestCommand
   implements IDownloadFileContentRequest
 {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/file/DownloadFileContentResponse.ts
+++ b/packages/test-utils/src/test-project/output/file/DownloadFileContentResponse.ts
@@ -57,18 +57,10 @@ export class DownloadFileContentSuccessResponse
   >
   implements IDownloadFileContentSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IDownloadFileContentSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for DownloadFileContentSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IDownloadFileContentSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/file/FileHono.ts
+++ b/packages/test-utils/src/test-project/output/file/FileHono.ts
@@ -45,6 +45,7 @@ export class FileHono extends TypeweaverHono<HonoFileApiHandler> {
     this.post("/files", async (context: Context) =>
       this.handleRequest(
         context,
+        "UploadFile",
         new UploadFileRequestValidator(),
         this.requestHandlers.handleUploadFileRequest.bind(this.requestHandlers),
       ),
@@ -53,6 +54,7 @@ export class FileHono extends TypeweaverHono<HonoFileApiHandler> {
     this.get("/files/:fileId", async (context: Context) =>
       this.handleRequest(
         context,
+        "GetFileMetadata",
         new GetFileMetadataRequestValidator(),
         this.requestHandlers.handleGetFileMetadataRequest.bind(this.requestHandlers),
       ),
@@ -61,6 +63,7 @@ export class FileHono extends TypeweaverHono<HonoFileApiHandler> {
     this.get("/files/:fileId/content", async (context: Context) =>
       this.handleRequest(
         context,
+        "DownloadFileContent",
         new DownloadFileContentRequestValidator(),
         this.requestHandlers.handleDownloadFileContentRequest.bind(this.requestHandlers),
       ),

--- a/packages/test-utils/src/test-project/output/file/FileRouter.ts
+++ b/packages/test-utils/src/test-project/output/file/FileRouter.ts
@@ -52,6 +52,7 @@ export class FileRouter<
 
   protected setupRoutes(): void {
     this.route(
+      "UploadFile",
       HttpMethod.POST,
       "/files",
       new UploadFileRequestValidator(),
@@ -59,6 +60,7 @@ export class FileRouter<
     );
 
     this.route(
+      "GetFileMetadata",
       HttpMethod.GET,
       "/files/:fileId",
       new GetFileMetadataRequestValidator(),
@@ -66,6 +68,7 @@ export class FileRouter<
     );
 
     this.route(
+      "DownloadFileContent",
       HttpMethod.GET,
       "/files/:fileId/content",
       new DownloadFileContentRequestValidator(),

--- a/packages/test-utils/src/test-project/output/file/GetFileMetadataRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/file/GetFileMetadataRequestCommand.ts
@@ -28,6 +28,7 @@ export class GetFileMetadataRequestCommand
   extends RequestCommand
   implements IGetFileMetadataRequest
 {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/file/GetFileMetadataResponse.ts
+++ b/packages/test-utils/src/test-project/output/file/GetFileMetadataResponse.ts
@@ -62,18 +62,10 @@ export class GetFileMetadataSuccessResponse
   extends HttpResponse<IGetFileMetadataSuccessResponseHeader, IGetFileMetadataSuccessResponseBody>
   implements IGetFileMetadataSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IGetFileMetadataSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for GetFileMetadataSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IGetFileMetadataSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/file/UploadFileRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/file/UploadFileRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { UploadFileSuccessResponse } from "./UploadFileResponse";
 
 export class UploadFileRequestCommand extends RequestCommand implements IUploadFileRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/file/UploadFileResponse.ts
+++ b/packages/test-utils/src/test-project/output/file/UploadFileResponse.ts
@@ -62,18 +62,10 @@ export class UploadFileSuccessResponse
   extends HttpResponse<IUploadFileSuccessResponseHeader, IUploadFileSuccessResponseBody>
   implements IUploadFileSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.CREATED;
+  public override readonly statusCode = HttpStatusCode.CREATED;
 
-  public constructor(response: IUploadFileSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CREATED) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UploadFileSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUploadFileSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.CREATED, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/lib/clients/RequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/lib/clients/RequestCommand.ts
@@ -48,6 +48,8 @@ export abstract class RequestCommand<
   Query extends IHttpQuery = IHttpQuery | undefined,
   Body extends IHttpBody = IHttpBody | undefined,
 > implements IHttpRequest {
+  /** Unique operation identifier from the API definition */
+  public readonly operationId!: string;
   /** The HTTP method for this request */
   public readonly method!: HttpMethod;
   /** The URL path pattern with parameter placeholders (e.g., '/users/:id') */

--- a/packages/test-utils/src/test-project/output/lib/hono/TypeweaverHono.ts
+++ b/packages/test-utils/src/test-project/output/lib/hono/TypeweaverHono.ts
@@ -289,16 +289,20 @@ export abstract class TypeweaverHono<
    * Handles a request with validation and type-safe response conversion.
    *
    * @param context - Hono context for the current request
+   * @param operationId - Unique operation identifier from the API definition
    * @param validator - Request validator for the specific operation
    * @param handler - Type-safe request handler function
    * @returns Hono-compatible Response object
    */
   protected async handleRequest<TRequest extends IHttpRequest, TResponse extends IHttpResponse>(
     context: Context,
+    operationId: string,
     validator: IRequestValidator,
     handler: HonoRequestHandler<TRequest, TResponse>,
   ): Promise<Response> {
     try {
+      context.set("operationId", operationId);
+
       const httpRequest = await this.adapter.toRequest(context);
 
       // Conditionally validate

--- a/packages/test-utils/src/test-project/output/lib/server/Router.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/Router.ts
@@ -15,9 +15,19 @@ import type { RequestHandler } from "./RequestHandler";
 import type { ServerContext } from "./ServerContext";
 
 /**
+ * Metadata about a matched route, available in middleware and handlers via `ctx.route`.
+ */
+export type RouteMetadata = {
+  readonly operationId: string;
+  readonly method: HttpMethod;
+  readonly path: string;
+};
+
+/**
  * A registered route with its method, path pattern, validator, and handler.
  */
 export type RouteDefinition = {
+  readonly operationId: string;
   readonly method: HttpMethod;
   readonly path: string;
   readonly validator: IRequestValidator;

--- a/packages/test-utils/src/test-project/output/lib/server/ServerContext.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/ServerContext.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IHttpRequest } from "@rexeus/typeweaver-core";
+import type { RouteMetadata } from "./Router";
 import type { StateMap } from "./StateMap";
 
 /**
@@ -49,4 +50,7 @@ export type ServerContext<TState extends Record<string, unknown> = Record<string
 
   /** Type-safe key-value store for sharing data between middleware and handlers. */
   readonly state: StateMap<TState>;
+
+  /** Metadata about the matched route, or `undefined` for 404/405 requests. */
+  readonly route: RouteMetadata | undefined;
 };

--- a/packages/test-utils/src/test-project/output/lib/server/TypeweaverApp.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/TypeweaverApp.ts
@@ -17,6 +17,7 @@ import type { RequestHandler } from "./RequestHandler";
 import type {
   HttpResponseErrorHandler,
   RouteDefinition,
+  RouteMatch,
   UnknownErrorHandler,
   ValidationErrorHandler,
 } from "./Router";
@@ -179,29 +180,36 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
     const url = new URL(request.url);
     const httpRequest = await this.adapter.toRequest(request, url);
 
+    const match = this.router.match(request.method, url.pathname);
+
     const ctx: ServerContext = {
       request: httpRequest,
       state: new StateMap(),
+      route: match
+        ? {
+            operationId: match.route.operationId,
+            method: match.route.method,
+            path: match.route.path,
+          }
+        : undefined,
     };
 
     const response = await executeMiddlewarePipeline(this.middlewares, ctx, () =>
-      this.resolveAndExecute(request.method, url.pathname, ctx),
+      this.resolveAndExecute(match, url.pathname, ctx),
     );
 
     return request.method.toUpperCase() === "HEAD" ? { ...response, body: undefined } : response;
   }
 
   /**
-   * Match the route and execute the handler.
+   * Execute the matched route handler, or produce 404/405 responses.
    * Called as the final handler in the middleware pipeline.
    */
   private async resolveAndExecute(
-    method: string,
+    match: RouteMatch | undefined,
     pathname: string,
     ctx: ServerContext,
   ): Promise<IHttpResponse> {
-    const match = this.router.match(method, pathname);
-
     if (match) {
       const routeCtx = this.withPathParams(ctx, match.params);
       try {

--- a/packages/test-utils/src/test-project/output/lib/server/TypeweaverRouter.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/TypeweaverRouter.ts
@@ -109,18 +109,21 @@ export abstract class TypeweaverRouter<
   /**
    * Register a route. Called by generated subclasses in their constructor.
    *
+   * @param operationId - Unique operation identifier from the API definition
    * @param method - HTTP method (GET, POST, PUT, DELETE, etc.)
    * @param path - Path pattern with `:param` placeholders
    * @param validator - Request validator for this operation
    * @param handler - Type-safe request handler
    */
   protected route(
+    operationId: string,
     method: HttpMethod,
     path: string,
     validator: IRequestValidator,
     handler: RequestHandler<any, any, any>,
   ): void {
     this.routes.push({
+      operationId,
       method,
       path,
       validator,

--- a/packages/test-utils/src/test-project/output/lib/server/index.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/index.ts
@@ -12,6 +12,7 @@ export { TypeweaverRouter, type TypeweaverRouterOptions } from "./TypeweaverRout
 export { HttpMethod } from "@rexeus/typeweaver-core";
 export type {
   HttpResponseErrorHandler,
+  RouteMetadata,
   UnknownErrorHandler,
   ValidationErrorHandler,
 } from "./Router";

--- a/packages/test-utils/src/test-project/output/shared/ConflictErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/ConflictErrorResponse.ts
@@ -29,15 +29,9 @@ export class ConflictErrorResponse
   extends HttpResponse<IConflictErrorResponseHeader, IConflictErrorResponseBody>
   implements IConflictErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.CONFLICT;
+  public override readonly statusCode = HttpStatusCode.CONFLICT;
 
-  public constructor(response: IConflictErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CONFLICT) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for ConflictErrorResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IConflictErrorResponse, "statusCode">) {
+    super(HttpStatusCode.CONFLICT, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/ForbiddenErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/ForbiddenErrorResponse.ts
@@ -29,15 +29,9 @@ export class ForbiddenErrorResponse
   extends HttpResponse<IForbiddenErrorResponseHeader, IForbiddenErrorResponseBody>
   implements IForbiddenErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.FORBIDDEN;
+  public override readonly statusCode = HttpStatusCode.FORBIDDEN;
 
-  public constructor(response: IForbiddenErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.FORBIDDEN) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for ForbiddenErrorResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IForbiddenErrorResponse, "statusCode">) {
+    super(HttpStatusCode.FORBIDDEN, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/InternalServerErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/InternalServerErrorResponse.ts
@@ -29,17 +29,9 @@ export class InternalServerErrorResponse
   extends HttpResponse<IInternalServerErrorResponseHeader, IInternalServerErrorResponseBody>
   implements IInternalServerErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.INTERNAL_SERVER_ERROR;
+  public override readonly statusCode = HttpStatusCode.INTERNAL_SERVER_ERROR;
 
-  public constructor(response: IInternalServerErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.INTERNAL_SERVER_ERROR) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for InternalServerErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IInternalServerErrorResponse, "statusCode">) {
+    super(HttpStatusCode.INTERNAL_SERVER_ERROR, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/NotFoundErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/NotFoundErrorResponse.ts
@@ -29,15 +29,9 @@ export class NotFoundErrorResponse
   extends HttpResponse<INotFoundErrorResponseHeader, INotFoundErrorResponseBody>
   implements INotFoundErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.NOT_FOUND;
+  public override readonly statusCode = HttpStatusCode.NOT_FOUND;
 
-  public constructor(response: INotFoundErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.NOT_FOUND) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for NotFoundErrorResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<INotFoundErrorResponse, "statusCode">) {
+    super(HttpStatusCode.NOT_FOUND, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/TooManyRequestsErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/TooManyRequestsErrorResponse.ts
@@ -29,17 +29,9 @@ export class TooManyRequestsErrorResponse
   extends HttpResponse<ITooManyRequestsErrorResponseHeader, ITooManyRequestsErrorResponseBody>
   implements ITooManyRequestsErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.TOO_MANY_REQUESTS;
+  public override readonly statusCode = HttpStatusCode.TOO_MANY_REQUESTS;
 
-  public constructor(response: ITooManyRequestsErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.TOO_MANY_REQUESTS) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for TooManyRequestsErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ITooManyRequestsErrorResponse, "statusCode">) {
+    super(HttpStatusCode.TOO_MANY_REQUESTS, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/UnauthorizedErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/UnauthorizedErrorResponse.ts
@@ -29,17 +29,9 @@ export class UnauthorizedErrorResponse
   extends HttpResponse<IUnauthorizedErrorResponseHeader, IUnauthorizedErrorResponseBody>
   implements IUnauthorizedErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.UNAUTHORIZED;
+  public override readonly statusCode = HttpStatusCode.UNAUTHORIZED;
 
-  public constructor(response: IUnauthorizedErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.UNAUTHORIZED) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UnauthorizedErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUnauthorizedErrorResponse, "statusCode">) {
+    super(HttpStatusCode.UNAUTHORIZED, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/UnprocessableEntityErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/UnprocessableEntityErrorResponse.ts
@@ -32,17 +32,9 @@ export class UnprocessableEntityErrorResponse
   >
   implements IUnprocessableEntityErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.UNPROCESSABLE_ENTITY;
+  public override readonly statusCode = HttpStatusCode.UNPROCESSABLE_ENTITY;
 
-  public constructor(response: IUnprocessableEntityErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.UNPROCESSABLE_ENTITY) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UnprocessableEntityErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUnprocessableEntityErrorResponse, "statusCode">) {
+    super(HttpStatusCode.UNPROCESSABLE_ENTITY, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/UnsupportedMediaTypeErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/UnsupportedMediaTypeErrorResponse.ts
@@ -38,17 +38,9 @@ export class UnsupportedMediaTypeErrorResponse
   >
   implements IUnsupportedMediaTypeErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.UNSUPPORTED_MEDIA_TYPE;
+  public override readonly statusCode = HttpStatusCode.UNSUPPORTED_MEDIA_TYPE;
 
-  public constructor(response: IUnsupportedMediaTypeErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.UNSUPPORTED_MEDIA_TYPE) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UnsupportedMediaTypeErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUnsupportedMediaTypeErrorResponse, "statusCode">) {
+    super(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/shared/ValidationErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/shared/ValidationErrorResponse.ts
@@ -35,15 +35,9 @@ export class ValidationErrorResponse
   extends HttpResponse<IValidationErrorResponseHeader, IValidationErrorResponseBody>
   implements IValidationErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.BAD_REQUEST;
+  public override readonly statusCode = HttpStatusCode.BAD_REQUEST;
 
-  public constructor(response: IValidationErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.BAD_REQUEST) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for ValidationErrorResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IValidationErrorResponse, "statusCode">) {
+    super(HttpStatusCode.BAD_REQUEST, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/CreateSubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateSubTodoRequestCommand.ts
@@ -26,6 +26,7 @@ import type {
 import { CreateSubTodoSuccessResponse } from "./CreateSubTodoResponse";
 
 export class CreateSubTodoRequestCommand extends RequestCommand implements ICreateSubTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/CreateSubTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateSubTodoResponse.ts
@@ -75,18 +75,10 @@ export class CreateSubTodoSuccessResponse
   extends HttpResponse<ICreateSubTodoSuccessResponseHeader, ICreateSubTodoSuccessResponseBody>
   implements ICreateSubTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.CREATED;
+  public override readonly statusCode = HttpStatusCode.CREATED;
 
-  public constructor(response: ICreateSubTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CREATED) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for CreateSubTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ICreateSubTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.CREATED, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/CreateTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateTodoRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { CreateTodoSuccessResponse } from "./CreateTodoResponse";
 
 export class CreateTodoRequestCommand extends RequestCommand implements ICreateTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/CreateTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateTodoResponse.ts
@@ -70,18 +70,10 @@ export class CreateTodoSuccessResponse
   extends HttpResponse<ICreateTodoSuccessResponseHeader, ICreateTodoSuccessResponseBody>
   implements ICreateTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.CREATED;
+  public override readonly statusCode = HttpStatusCode.CREATED;
 
-  public constructor(response: ICreateTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CREATED) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for CreateTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ICreateTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.CREATED, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/DeleteSubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteSubTodoRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { DeleteSubTodoSuccessResponse } from "./DeleteSubTodoResponse";
 
 export class DeleteSubTodoRequestCommand extends RequestCommand implements IDeleteSubTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.DELETE;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/DeleteSubTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteSubTodoResponse.ts
@@ -68,18 +68,10 @@ export class DeleteSubTodoSuccessResponse
   extends HttpResponse<IDeleteSubTodoSuccessResponseHeader, IDeleteSubTodoSuccessResponseBody>
   implements IDeleteSubTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IDeleteSubTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for DeleteSubTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IDeleteSubTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/DeleteTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteTodoRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { DeleteTodoSuccessResponse } from "./DeleteTodoResponse";
 
 export class DeleteTodoRequestCommand extends RequestCommand implements IDeleteTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.DELETE;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/DeleteTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteTodoResponse.ts
@@ -58,18 +58,10 @@ export class DeleteTodoSuccessResponse
   extends HttpResponse<IDeleteTodoSuccessResponseHeader, undefined>
   implements IDeleteTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.NO_CONTENT;
+  public override readonly statusCode = HttpStatusCode.NO_CONTENT;
 
-  public constructor(response: IDeleteTodoSuccessResponse) {
-    super(response.statusCode, response.header, undefined);
-
-    if (response.statusCode !== HttpStatusCode.NO_CONTENT) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for DeleteTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IDeleteTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.NO_CONTENT, response.header, undefined);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/GetTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/GetTodoRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { GetTodoSuccessResponse } from "./GetTodoResponse";
 
 export class GetTodoRequestCommand extends RequestCommand implements IGetTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/GetTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/GetTodoResponse.ts
@@ -75,16 +75,10 @@ export class GetTodoSuccessResponse
   extends HttpResponse<IGetTodoSuccessResponseHeader, IGetTodoSuccessResponseBody>
   implements IGetTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IGetTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for GetTodoSuccessResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IGetTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/HeadTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/HeadTodoRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { HeadTodoSuccessResponse } from "./HeadTodoResponse";
 
 export class HeadTodoRequestCommand extends RequestCommand implements IHeadTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.HEAD;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/HeadTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/HeadTodoResponse.ts
@@ -58,16 +58,10 @@ export class HeadTodoSuccessResponse
   extends HttpResponse<IHeadTodoSuccessResponseHeader, undefined>
   implements IHeadTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IHeadTodoSuccessResponse) {
-    super(response.statusCode, response.header, undefined);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for HeadTodoSuccessResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IHeadTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, undefined);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/ListSubTodosRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListSubTodosRequestCommand.ts
@@ -26,6 +26,7 @@ import type {
 import { ListSubTodosSuccessResponse } from "./ListSubTodosResponse";
 
 export class ListSubTodosRequestCommand extends RequestCommand implements IListSubTodosRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/ListSubTodosResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListSubTodosResponse.ts
@@ -78,18 +78,10 @@ export class ListSubTodosSuccessResponse
   extends HttpResponse<IListSubTodosSuccessResponseHeader, IListSubTodosSuccessResponseBody>
   implements IListSubTodosSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IListSubTodosSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for ListSubTodosSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IListSubTodosSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/ListTodosRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListTodosRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { ListTodosSuccessResponse } from "./ListTodosResponse";
 
 export class ListTodosRequestCommand extends RequestCommand implements IListTodosRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/ListTodosResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListTodosResponse.ts
@@ -73,16 +73,10 @@ export class ListTodosSuccessResponse
   extends HttpResponse<IListTodosSuccessResponseHeader, IListTodosSuccessResponseBody>
   implements IListTodosSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IListTodosSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for ListTodosSuccessResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IListTodosSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/OptionsTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/OptionsTodoRequestCommand.ts
@@ -25,6 +25,7 @@ import type {
 import { OptionsTodoSuccessResponse } from "./OptionsTodoResponse";
 
 export class OptionsTodoRequestCommand extends RequestCommand implements IOptionsTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.OPTIONS;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/OptionsTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/OptionsTodoResponse.ts
@@ -60,18 +60,10 @@ export class OptionsTodoSuccessResponse
   extends HttpResponse<IOptionsTodoSuccessResponseHeader, undefined>
   implements IOptionsTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IOptionsTodoSuccessResponse) {
-    super(response.statusCode, response.header, undefined);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for OptionsTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IOptionsTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, undefined);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/PutTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/PutTodoRequestCommand.ts
@@ -26,6 +26,7 @@ import type {
 import { PutTodoSuccessResponse } from "./PutTodoResponse";
 
 export class PutTodoRequestCommand extends RequestCommand implements IPutTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PUT;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/PutTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/PutTodoResponse.ts
@@ -80,16 +80,10 @@ export class PutTodoSuccessResponse
   extends HttpResponse<IPutTodoSuccessResponseHeader, IPutTodoSuccessResponseBody>
   implements IPutTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IPutTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for PutTodoSuccessResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IPutTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/QuerySubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/QuerySubTodoRequestCommand.ts
@@ -27,6 +27,7 @@ import type {
 import { QuerySubTodoSuccessResponse } from "./QuerySubTodoResponse";
 
 export class QuerySubTodoRequestCommand extends RequestCommand implements IQuerySubTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/QuerySubTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/QuerySubTodoResponse.ts
@@ -78,18 +78,10 @@ export class QuerySubTodoSuccessResponse
   extends HttpResponse<IQuerySubTodoSuccessResponseHeader, IQuerySubTodoSuccessResponseBody>
   implements IQuerySubTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IQuerySubTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for QuerySubTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IQuerySubTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/QueryTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/QueryTodoRequestCommand.ts
@@ -26,6 +26,7 @@ import type {
 import { QueryTodoSuccessResponse } from "./QueryTodoResponse";
 
 export class QueryTodoRequestCommand extends RequestCommand implements IQueryTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/QueryTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/QueryTodoResponse.ts
@@ -73,16 +73,10 @@ export class QueryTodoSuccessResponse
   extends HttpResponse<IQueryTodoSuccessResponseHeader, IQueryTodoSuccessResponseBody>
   implements IQueryTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IQueryTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(`Invalid status code: '${response.statusCode}' for QueryTodoSuccessResponse`);
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IQueryTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/SubTodoNotChangeableErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/SubTodoNotChangeableErrorResponse.ts
@@ -42,17 +42,9 @@ export class SubTodoNotChangeableErrorResponse
   >
   implements ISubTodoNotChangeableErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.CONFLICT;
+  public override readonly statusCode = HttpStatusCode.CONFLICT;
 
-  public constructor(response: ISubTodoNotChangeableErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CONFLICT) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for SubTodoNotChangeableErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ISubTodoNotChangeableErrorResponse, "statusCode">) {
+    super(HttpStatusCode.CONFLICT, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/SubTodoNotFoundErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/SubTodoNotFoundErrorResponse.ts
@@ -35,17 +35,9 @@ export class SubTodoNotFoundErrorResponse
   extends HttpResponse<ISubTodoNotFoundErrorResponseHeader, ISubTodoNotFoundErrorResponseBody>
   implements ISubTodoNotFoundErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.NOT_FOUND;
+  public override readonly statusCode = HttpStatusCode.NOT_FOUND;
 
-  public constructor(response: ISubTodoNotFoundErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.NOT_FOUND) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for SubTodoNotFoundErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ISubTodoNotFoundErrorResponse, "statusCode">) {
+    super(HttpStatusCode.NOT_FOUND, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/SubTodoStatusTransitionInvalidErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/SubTodoStatusTransitionInvalidErrorResponse.ts
@@ -44,17 +44,9 @@ export class SubTodoStatusTransitionInvalidErrorResponse
   >
   implements ISubTodoStatusTransitionInvalidErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.CONFLICT;
+  public override readonly statusCode = HttpStatusCode.CONFLICT;
 
-  public constructor(response: ISubTodoStatusTransitionInvalidErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CONFLICT) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for SubTodoStatusTransitionInvalidErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ISubTodoStatusTransitionInvalidErrorResponse, "statusCode">) {
+    super(HttpStatusCode.CONFLICT, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/TodoHono.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoHono.ts
@@ -108,6 +108,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.get("/todos", async (context: Context) =>
       this.handleRequest(
         context,
+        "ListTodos",
         new ListTodosRequestValidator(),
         this.requestHandlers.handleListTodosRequest.bind(this.requestHandlers),
       ),
@@ -116,6 +117,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.post("/todos", async (context: Context) =>
       this.handleRequest(
         context,
+        "CreateTodo",
         new CreateTodoRequestValidator(),
         this.requestHandlers.handleCreateTodoRequest.bind(this.requestHandlers),
       ),
@@ -124,6 +126,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.post("/todos/query", async (context: Context) =>
       this.handleRequest(
         context,
+        "QueryTodo",
         new QueryTodoRequestValidator(),
         this.requestHandlers.handleQueryTodoRequest.bind(this.requestHandlers),
       ),
@@ -132,6 +135,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.get("/todos/:todoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "GetTodo",
         new GetTodoRequestValidator(),
         this.requestHandlers.handleGetTodoRequest.bind(this.requestHandlers),
       ),
@@ -140,6 +144,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.put("/todos/:todoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "PutTodo",
         new PutTodoRequestValidator(),
         this.requestHandlers.handlePutTodoRequest.bind(this.requestHandlers),
       ),
@@ -148,6 +153,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.patch("/todos/:todoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "UpdateTodo",
         new UpdateTodoRequestValidator(),
         this.requestHandlers.handleUpdateTodoRequest.bind(this.requestHandlers),
       ),
@@ -156,6 +162,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.delete("/todos/:todoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "DeleteTodo",
         new DeleteTodoRequestValidator(),
         this.requestHandlers.handleDeleteTodoRequest.bind(this.requestHandlers),
       ),
@@ -164,6 +171,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.options("/todos/:todoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "OptionsTodo",
         new OptionsTodoRequestValidator(),
         this.requestHandlers.handleOptionsTodoRequest.bind(this.requestHandlers),
       ),
@@ -172,6 +180,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.put("/todos/:todoId/status", async (context: Context) =>
       this.handleRequest(
         context,
+        "UpdateTodoStatus",
         new UpdateTodoStatusRequestValidator(),
         this.requestHandlers.handleUpdateTodoStatusRequest.bind(this.requestHandlers),
       ),
@@ -180,6 +189,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.get("/todos/:todoId/subtodos", async (context: Context) =>
       this.handleRequest(
         context,
+        "ListSubTodos",
         new ListSubTodosRequestValidator(),
         this.requestHandlers.handleListSubTodosRequest.bind(this.requestHandlers),
       ),
@@ -188,6 +198,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.post("/todos/:todoId/subtodos", async (context: Context) =>
       this.handleRequest(
         context,
+        "CreateSubTodo",
         new CreateSubTodoRequestValidator(),
         this.requestHandlers.handleCreateSubTodoRequest.bind(this.requestHandlers),
       ),
@@ -196,6 +207,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.post("/todos/:todoId/subtodos/query", async (context: Context) =>
       this.handleRequest(
         context,
+        "QuerySubTodo",
         new QuerySubTodoRequestValidator(),
         this.requestHandlers.handleQuerySubTodoRequest.bind(this.requestHandlers),
       ),
@@ -204,6 +216,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.put("/todos/:todoId/subtodos/:subtodoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "UpdateSubTodo",
         new UpdateSubTodoRequestValidator(),
         this.requestHandlers.handleUpdateSubTodoRequest.bind(this.requestHandlers),
       ),
@@ -212,6 +225,7 @@ export class TodoHono extends TypeweaverHono<HonoTodoApiHandler> {
     this.delete("/todos/:todoId/subtodos/:subtodoId", async (context: Context) =>
       this.handleRequest(
         context,
+        "DeleteSubTodo",
         new DeleteSubTodoRequestValidator(),
         this.requestHandlers.handleDeleteSubTodoRequest.bind(this.requestHandlers),
       ),

--- a/packages/test-utils/src/test-project/output/todo/TodoNotChangeableErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoNotChangeableErrorResponse.ts
@@ -36,17 +36,9 @@ export class TodoNotChangeableErrorResponse
   extends HttpResponse<ITodoNotChangeableErrorResponseHeader, ITodoNotChangeableErrorResponseBody>
   implements ITodoNotChangeableErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.CONFLICT;
+  public override readonly statusCode = HttpStatusCode.CONFLICT;
 
-  public constructor(response: ITodoNotChangeableErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CONFLICT) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for TodoNotChangeableErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ITodoNotChangeableErrorResponse, "statusCode">) {
+    super(HttpStatusCode.CONFLICT, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/TodoNotFoundErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoNotFoundErrorResponse.ts
@@ -32,17 +32,9 @@ export class TodoNotFoundErrorResponse
   extends HttpResponse<ITodoNotFoundErrorResponseHeader, ITodoNotFoundErrorResponseBody>
   implements ITodoNotFoundErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.NOT_FOUND;
+  public override readonly statusCode = HttpStatusCode.NOT_FOUND;
 
-  public constructor(response: ITodoNotFoundErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.NOT_FOUND) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for TodoNotFoundErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ITodoNotFoundErrorResponse, "statusCode">) {
+    super(HttpStatusCode.NOT_FOUND, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/TodoRouter.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoRouter.ts
@@ -126,6 +126,7 @@ export class TodoRouter<
 
   protected setupRoutes(): void {
     this.route(
+      "ListTodos",
       HttpMethod.GET,
       "/todos",
       new ListTodosRequestValidator(),
@@ -133,6 +134,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "CreateTodo",
       HttpMethod.POST,
       "/todos",
       new CreateTodoRequestValidator(),
@@ -140,6 +142,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "QueryTodo",
       HttpMethod.POST,
       "/todos/query",
       new QueryTodoRequestValidator(),
@@ -147,6 +150,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "GetTodo",
       HttpMethod.GET,
       "/todos/:todoId",
       new GetTodoRequestValidator(),
@@ -154,6 +158,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "PutTodo",
       HttpMethod.PUT,
       "/todos/:todoId",
       new PutTodoRequestValidator(),
@@ -161,6 +166,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "UpdateTodo",
       HttpMethod.PATCH,
       "/todos/:todoId",
       new UpdateTodoRequestValidator(),
@@ -168,6 +174,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "DeleteTodo",
       HttpMethod.DELETE,
       "/todos/:todoId",
       new DeleteTodoRequestValidator(),
@@ -175,6 +182,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "OptionsTodo",
       HttpMethod.OPTIONS,
       "/todos/:todoId",
       new OptionsTodoRequestValidator(),
@@ -182,6 +190,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "UpdateTodoStatus",
       HttpMethod.PUT,
       "/todos/:todoId/status",
       new UpdateTodoStatusRequestValidator(),
@@ -189,6 +198,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "ListSubTodos",
       HttpMethod.GET,
       "/todos/:todoId/subtodos",
       new ListSubTodosRequestValidator(),
@@ -196,6 +206,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "CreateSubTodo",
       HttpMethod.POST,
       "/todos/:todoId/subtodos",
       new CreateSubTodoRequestValidator(),
@@ -203,6 +214,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "QuerySubTodo",
       HttpMethod.POST,
       "/todos/:todoId/subtodos/query",
       new QuerySubTodoRequestValidator(),
@@ -210,6 +222,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "UpdateSubTodo",
       HttpMethod.PUT,
       "/todos/:todoId/subtodos/:subtodoId",
       new UpdateSubTodoRequestValidator(),
@@ -217,6 +230,7 @@ export class TodoRouter<
     );
 
     this.route(
+      "DeleteSubTodo",
       HttpMethod.DELETE,
       "/todos/:todoId/subtodos/:subtodoId",
       new DeleteSubTodoRequestValidator(),

--- a/packages/test-utils/src/test-project/output/todo/TodoStatusTransitionInvalidErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoStatusTransitionInvalidErrorResponse.ts
@@ -42,17 +42,9 @@ export class TodoStatusTransitionInvalidErrorResponse
   >
   implements ITodoStatusTransitionInvalidErrorResponse
 {
-  public override readonly statusCode: HttpStatusCode.CONFLICT;
+  public override readonly statusCode = HttpStatusCode.CONFLICT;
 
-  public constructor(response: ITodoStatusTransitionInvalidErrorResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.CONFLICT) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for TodoStatusTransitionInvalidErrorResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<ITodoStatusTransitionInvalidErrorResponse, "statusCode">) {
+    super(HttpStatusCode.CONFLICT, response.header, response.body);
   }
 }

--- a/packages/test-utils/src/test-project/output/todo/UpdateSubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateSubTodoRequestCommand.ts
@@ -26,6 +26,7 @@ import type {
 import { UpdateSubTodoSuccessResponse } from "./UpdateSubTodoResponse";
 
 export class UpdateSubTodoRequestCommand extends RequestCommand implements IUpdateSubTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PUT;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateSubTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateSubTodoResponse.ts
@@ -90,18 +90,10 @@ export class UpdateSubTodoSuccessResponse
   extends HttpResponse<IUpdateSubTodoSuccessResponseHeader, IUpdateSubTodoSuccessResponseBody>
   implements IUpdateSubTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IUpdateSubTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UpdateSubTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUpdateSubTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoRequestCommand.ts
@@ -26,6 +26,7 @@ import type {
 import { UpdateTodoSuccessResponse } from "./UpdateTodoResponse";
 
 export class UpdateTodoRequestCommand extends RequestCommand implements IUpdateTodoRequest {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PATCH;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoResponse.ts
@@ -80,18 +80,10 @@ export class UpdateTodoSuccessResponse
   extends HttpResponse<IUpdateTodoSuccessResponseHeader, IUpdateTodoSuccessResponseBody>
   implements IUpdateTodoSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IUpdateTodoSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UpdateTodoSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUpdateTodoSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusRequestCommand.ts
@@ -29,6 +29,7 @@ export class UpdateTodoStatusRequestCommand
   extends RequestCommand
   implements IUpdateTodoStatusRequest
 {
+  public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PUT;
   public override readonly path = definition.path;
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusResponse.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusResponse.ts
@@ -85,18 +85,10 @@ export class UpdateTodoStatusSuccessResponse
   extends HttpResponse<IUpdateTodoStatusSuccessResponseHeader, IUpdateTodoStatusSuccessResponseBody>
   implements IUpdateTodoStatusSuccessResponse
 {
-  public override readonly statusCode: HttpStatusCode.OK;
+  public override readonly statusCode = HttpStatusCode.OK;
 
-  public constructor(response: IUpdateTodoStatusSuccessResponse) {
-    super(response.statusCode, response.header, response.body);
-
-    if (response.statusCode !== HttpStatusCode.OK) {
-      throw new Error(
-        `Invalid status code: '${response.statusCode}' for UpdateTodoStatusSuccessResponse`,
-      );
-    }
-
-    this.statusCode = response.statusCode;
+  public constructor(response: Omit<IUpdateTodoStatusSuccessResponse, "statusCode">) {
+    super(HttpStatusCode.OK, response.header, response.body);
   }
 }
 

--- a/packages/types/src/templates/Response.ejs
+++ b/packages/types/src/templates/Response.ejs
@@ -34,21 +34,25 @@ import type { I<%= entityResponse.name %>Response, <%= entityResponse.name %>Res
             <%= ownResponse.header ? `I${ownResponse.name}ResponseHeader` : 'undefined' %>,
             <%= ownResponse.body ? `I${ownResponse.name}ResponseBody` : 'undefined' %>
             > implements I<%= ownResponse.name %>Response {
-        public override readonly statusCode: HttpStatusCode.<%= ownResponse.statusCodeKey %>;
+        public override readonly statusCode = HttpStatusCode.<%= ownResponse.statusCodeKey %>;
 
-        public constructor(response: I<%= ownResponse.name %>Response) {
+<% if (ownResponse.header || ownResponse.body) { %>
+        public constructor(response: Omit<I<%= ownResponse.name %>Response, "statusCode">) {
             super(
-                response.statusCode,
+                HttpStatusCode.<%= ownResponse.statusCodeKey %>,
                 <%= ownResponse.header ? `response.header` : 'undefined' %>,
                 <%= ownResponse.body ? `response.body` : 'undefined' %>,
             );
-
-            if(response.statusCode !== HttpStatusCode.<%= ownResponse.statusCodeKey %>) {
-                throw new Error(`Invalid status code: '${response.statusCode}' for <%= ownResponse.name %>Response`);
-            }
-
-            this.statusCode = response.statusCode;
         }
+<% } else { %>
+        public constructor() {
+            super(
+                HttpStatusCode.<%= ownResponse.statusCodeKey %>,
+                undefined,
+                undefined,
+            );
+        }
+<% } %>
     }
 <% } %>
 

--- a/packages/types/src/templates/ResponseValidator.ejs
+++ b/packages/types/src/templates/ResponseValidator.ejs
@@ -89,7 +89,11 @@ export class <%= pascalCaseOperationId %>ResponseValidator extends ResponseValid
             return result;
         }
 
+<% if (response.hasHeader || response.hasBody) { %>
         return { isValid: true, data: new <%= response.name %>Response(result.data as I<%= response.name %>Response) };
+<% } else { %>
+        return { isValid: true, data: new <%= response.name %>Response() };
+<% } %>
     }
     <% } %>
 }

--- a/packages/types/src/templates/SharedResponse.ejs
+++ b/packages/types/src/templates/SharedResponse.ejs
@@ -26,21 +26,25 @@ export class <%= pascalCaseName %>Response extends HttpResponse<
 <%= sharedResponse.header ? `I${pascalCaseName}ResponseHeader` : 'undefined' %>,
 <%= sharedResponse.body ? `I${pascalCaseName}ResponseBody` : 'undefined' %>
 > implements I<%= pascalCaseName %>Response {
-public override readonly statusCode: HttpStatusCode.<%= httpStatusCode[sharedResponse.statusCode] %>;
+public override readonly statusCode = HttpStatusCode.<%= httpStatusCode[sharedResponse.statusCode] %>;
 
-public constructor(response: I<%= pascalCaseName %>Response) {
+<% if (sharedResponse.header || sharedResponse.body) { %>
+public constructor(response: Omit<I<%= pascalCaseName %>Response, "statusCode">) {
     super(
-        response.statusCode,
+        HttpStatusCode.<%= httpStatusCode[sharedResponse.statusCode] %>,
         <%= sharedResponse.header ? `response.header` : 'undefined' %>,
         <%= sharedResponse.body ? `response.body` : 'undefined' %>,
     );
-
-    if (response.statusCode !== HttpStatusCode.<%= httpStatusCode[sharedResponse.statusCode] %>) {
-        throw new Error(`Invalid status code: '${response.statusCode}' for <%= pascalCaseName %>Response`);
-    }
-
-    this.statusCode = response.statusCode;
 }
+<% } else { %>
+public constructor() {
+    super(
+        HttpStatusCode.<%= httpStatusCode[sharedResponse.statusCode] %>,
+        undefined,
+        undefined,
+    );
+}
+<% } %>
 }
 
 


### PR DESCRIPTION
Enhance the API by adding an operationId property across various components, including RequestCommand and Hono middleware.