### PR TITLE
fix(server): return ArrayBuffer instead of Uint8Array/Buffer from body collectors

### DIFF
--- a/.changeset/ten-lands-nail.md
+++ b/.changeset/ten-lands-nail.md
@@ -1,0 +1,5 @@
+---
+"@rexeus/typeweaver-server": patch
+---
+
+Return ArrayBuffer instead of Uint8Array/Buffer from body collectors for broader runtime compatibility

--- a/packages/server/src/lib/FetchApiAdapter.ts
+++ b/packages/server/src/lib/FetchApiAdapter.ts
@@ -284,14 +284,14 @@ export class FetchApiAdapter {
   private static concatChunks(
     chunks: Uint8Array[],
     totalBytes: number
-  ): Uint8Array {
+  ): ArrayBuffer {
     const buffer = new Uint8Array(totalBytes);
     let offset = 0;
     for (const chunk of chunks) {
       buffer.set(chunk, offset);
       offset += chunk.byteLength;
     }
-    return buffer;
+    return buffer.buffer as ArrayBuffer;
   }
 
   private static serializeResponseBody(

--- a/packages/server/src/lib/NodeAdapter.ts
+++ b/packages/server/src/lib/NodeAdapter.ts
@@ -103,8 +103,8 @@ async function handleRequest(
 function collectBody(
   req: IncomingMessage,
   maxBodySize: number
-): Promise<Buffer> {
-  return new Promise<Buffer>((resolve, reject) => {
+): Promise<ArrayBuffer> {
+  return new Promise<ArrayBuffer>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
 
@@ -118,7 +118,15 @@ function collectBody(
       chunks.push(chunk);
     });
 
-    req.on("end", () => resolve(Buffer.concat(chunks, totalBytes)));
+    req.on("end", () => {
+      const combined = Buffer.concat(chunks, totalBytes);
+      resolve(
+        combined.buffer.slice(
+          combined.byteOffset,
+          combined.byteOffset + combined.byteLength
+        ) as ArrayBuffer
+      );
+    });
     req.on("error", reject);
   });
 }

--- a/packages/test-utils/src/test-project/output/lib/server/FetchApiAdapter.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/FetchApiAdapter.ts
@@ -262,14 +262,14 @@ export class FetchApiAdapter {
     });
   }
 
-  private static concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  private static concatChunks(chunks: Uint8Array[], totalBytes: number): ArrayBuffer {
     const buffer = new Uint8Array(totalBytes);
     let offset = 0;
     for (const chunk of chunks) {
       buffer.set(chunk, offset);
       offset += chunk.byteLength;
     }
-    return buffer;
+    return buffer.buffer as ArrayBuffer;
   }
 
   private static serializeResponseBody(body: any): string | ArrayBuffer | Blob | null {

--- a/packages/test-utils/src/test-project/output/lib/server/NodeAdapter.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/NodeAdapter.ts
@@ -96,8 +96,8 @@ async function handleRequest(
   }
 }
 
-function collectBody(req: IncomingMessage, maxBodySize: number): Promise<Buffer> {
-  return new Promise<Buffer>((resolve, reject) => {
+function collectBody(req: IncomingMessage, maxBodySize: number): Promise<ArrayBuffer> {
+  return new Promise<ArrayBuffer>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
 
@@ -111,7 +111,15 @@ function collectBody(req: IncomingMessage, maxBodySize: number): Promise<Buffer>
       chunks.push(chunk);
     });
 
-    req.on("end", () => resolve(Buffer.concat(chunks, totalBytes)));
+    req.on("end", () => {
+      const combined = Buffer.concat(chunks, totalBytes);
+      resolve(
+        combined.buffer.slice(
+          combined.byteOffset,
+          combined.byteOffset + combined.byteLength,
+        ) as ArrayBuffer,
+      );
+    });
     req.on("error", reject);
   });
 }


### PR DESCRIPTION
## Summary

Body collector functions in `FetchApiAdapter` and `NodeAdapter` returned `Uint8Array` / `Buffer` which some runtimes (e.g. Cloudflare Workers, Bun) reject when passed to the `Request` constructor. This changes both adapters to return proper `ArrayBuffer` instances.

## Changes

- `FetchApiAdapter.concatChunks` now returns the backing `ArrayBuffer` of the assembled `Uint8Array`
- `NodeAdapter.collectBody` extracts a clean `ArrayBuffer` via `buffer.slice(byteOffset, byteOffset + byteLength)` to safely handle Node.js Buffer pool allocations
- Mirrored changes in `test-utils` output files

## Test Plan

- `pnpm run typecheck` — verify no type errors from the `ArrayBuffer` return types
- `pnpm run test` — ensure existing request/response tests still pass