### PR TITLE
docs: remove misplaced naming conventions from readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,6 @@ Typeweaver is a type-safe HTTP API framework built for API-first development wit
 developer experience. Use typeweaver to specify your HTTP APIs in TypeScript and Zod, and generate
 clients, validators, routers, and more ✨
 
-### Naming conventions
-
-- `operationId` should use camelCase (preferred), for example `getUser`.
-- PascalCase `operationId` values are supported for compatibility.
-- `operationId` values in snake_case or kebab-case are not supported.
-- `resourceName` should preferably be a singular noun in camelCase, for example `user` or
-  `authSession`.
-- Plural and PascalCase `resourceName` values are supported.
-- `resourceName` values in snake_case or kebab-case are not supported.
-
----
-
 ## 📥 Installation
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,16 +34,6 @@ bun add @rexeus/typeweaver-core
 
 Now you are ready to start building! Check out [Quickstart](#-get-started)
 
-## 🏷️ Naming conventions
-
-- `operationId` should use camelCase (preferred), for example `getUser`.
-- PascalCase `operationId` values are supported for compatibility.
-- snake_case and kebab-case `operationId` values are not supported.
-- `resourceName` should preferably be a singular noun in camelCase, for example `user` or
-  `authSession`.
-- Plural and PascalCase `resourceName` values are supported.
-- snake_case and kebab-case `resourceName` values are not supported.
-
 ## 🎯 Why typeweaver?
 
 - 📝 **Define once, generate everything**: API contracts in Zod become clients, servers, validators,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,16 +42,6 @@ This package is typically consumed by generated code. You also use it when autho
 This package does not ship framework adapters. Use plugins like `@rexeus/typeweaver-hono` or
 `@rexeus/typeweaver-aws-cdk` for routers/integrations.
 
-## 🏷️ Naming conventions
-
-- `operationId` should use camelCase (preferred), for example `getUser`.
-- PascalCase `operationId` values are still supported.
-- snake_case and kebab-case `operationId` values are not supported.
-- `resourceName` should preferably be a singular noun in camelCase, for example `user` or
-  `authSession`.
-- Plural and PascalCase `resourceName` values are supported.
-- snake_case and kebab-case `resourceName` values are not supported.
-
 ## 📄 License
 
 Apache 2.0 © Dennis Wentzien 2026

--- a/packages/gen/README.md
+++ b/packages/gen/README.md
@@ -27,18 +27,6 @@ Most users don’t depend on this package directly — use the CLI instead:
 [`@rexeus/typeweaver`](https://github.com/rexeus/typeweaver/tree/main/packages/cli/README.md). If
 you’re writing a plugin, start here.
 
-## 🏷️ Spec naming validation
-
-The normalization pipeline validates supported naming formats before generation:
-
-- `operationId` should use camelCase (preferred), for example `getUser`.
-- PascalCase `operationId` values are supported for compatibility.
-- snake_case and kebab-case `operationId` values are rejected during normalization.
-- `resourceName` should preferably be a singular noun in camelCase, for example `user` or
-  `authSession`.
-- Plural and PascalCase `resourceName` values are supported.
-- snake_case and kebab-case `resourceName` values are rejected during normalization.
-
 ### 🚀 Minimal plugin
 
 ```ts
@@ -186,6 +174,18 @@ output.
   [here](https://github.com/rexeus/typeweaver/tree/main/packages/cli/README.md#️-options).
 - Keep plugins focused: one concern per plugin (clients, routers, infra).
 - Prefer `GeneratorContext.writeFile` over manual fs writes for tracking and directory setup.
+
+### 🏷️ Spec naming validation
+
+The normalization pipeline validates supported naming formats before generation:
+
+- `operationId` should use camelCase (preferred), for example `getUser`.
+- PascalCase `operationId` values are supported for compatibility.
+- snake_case and kebab-case `operationId` values are rejected during normalization.
+- `resourceName` should preferably be a singular noun in camelCase, for example `user` or
+  `authSession`.
+- Plural and PascalCase `resourceName` values are supported.
+- snake_case and kebab-case `resourceName` values are rejected during normalization.
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary

Clean up README structure by removing naming-convention guidance from places
where it distracts from the main flow of the documentation.

Keep generator-specific validation guidance in the gen README, but move it to a
later section where plugin authors are more likely to expect it.

## Changes

- Remove prominent naming-convention sections from the root, CLI, and core
  READMEs so installation, quickstart, and package-purpose sections stay
  focused.
- Keep the root and CLI examples self-explanatory instead of repeating naming
  rules directly above them.
- Move `Spec naming validation` in `packages/gen/README.md` from the early
  guide flow into `Notes`, where generator-specific validation details fit
  better.