### PR TITLE
fix: harden generated clients and server error handling

### DIFF
--- a/.changeset/fix-sequenced-docs-issues.md
+++ b/.changeset/fix-sequenced-docs-issues.md
@@ -1,0 +1,11 @@
+---
+"@rexeus/typeweaver-core": patch
+"@rexeus/typeweaver-gen": patch
+"@rexeus/typeweaver-types": patch
+"@rexeus/typeweaver-clients": patch
+"@rexeus/typeweaver-server": patch
+"@rexeus/typeweaver-hono": patch
+"@rexeus/typeweaver-aws-cdk": patch
+---
+
+Fix generated literal request headers, align typed response header optionality with runtime behavior, emit sanitized generated JSDoc, and validate transformed thrown typed HTTP responses after `handleHttpResponseErrors`. Clarify custom unknown error reporting semantics.

--- a/packages/aws-cdk/src/httpApiRouterGenerator.ts
+++ b/packages/aws-cdk/src/httpApiRouterGenerator.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HttpMethod } from "@rexeus/typeweaver-core";
+import { createJSDocComment } from "@rexeus/typeweaver-gen";
 import type {
   GeneratorContext,
   NormalizedResource,
@@ -22,7 +23,13 @@ function writeHttpApiRoutes(
   templateFile: string,
   context: GeneratorContext
 ): void {
-  const routes: Record<string, HttpMethod[]> = {};
+  const routes: Record<
+    string,
+    {
+      readonly methods: HttpMethod[];
+      readonly methodSummaries: string[];
+    }
+  > = {};
   const pascalCaseEntityName = pascalCase(resource.name);
   const outputDir = context.getResourceOutputDir(resource.name);
   const outputFile = path.join(
@@ -34,16 +41,36 @@ function writeHttpApiRoutes(
     const routePath = createRoutePath(operation.path);
 
     if (!routes[routePath]) {
-      routes[routePath] = [];
+      routes[routePath] = {
+        methods: [],
+        methodSummaries: [],
+      };
     }
 
-    routes[routePath]!.push(operation.method);
+    routes[routePath]!.methods.push(operation.method);
+    routes[routePath]!.methodSummaries.push(
+      operation.summary
+        ? `${operation.method}: ${operation.summary}`
+        : operation.method
+    );
   }
+
+  const routesWithDocs = Object.fromEntries(
+    Object.entries(routes).map(([routePath, route]) => [
+      routePath,
+      {
+        methods: route.methods,
+        jsDoc: createJSDocComment(route.methodSummaries.join("\n"), {
+          indentation: "      ",
+        }),
+      },
+    ])
+  );
 
   const content = context.renderTemplate(templateFile, {
     entityName: resource.name,
     pascalCaseEntityName,
-    routes,
+    routes: routesWithDocs,
     coreDir: context.coreDir,
   });
 

--- a/packages/aws-cdk/src/templates/HttpApiRouter.ejs
+++ b/packages/aws-cdk/src/templates/HttpApiRouter.ejs
@@ -14,10 +14,11 @@ import {
 
 export class <%= pascalCaseEntityName %>HttpApiRoutes extends AwsHttpApiGatewayRoutes {
   private routes: AwsHttpApiGatewayRoute[] = [
-<% for(const [path, methods] of Object.entries(routes)) { %>
+<% for(const [path, route] of Object.entries(routes)) { %>
     {
-      path: "<%= path %>",
-      methods: [<% for(const method of methods) { %>HttpMethod.<%= method %>,<% } %>],
+<% if (route.jsDoc) { %><%- route.jsDoc %>
+<% } %>      path: "<%= path %>",
+      methods: [<% for(const method of route.methods) { %>HttpMethod.<%= method %>,<% } %>],
     },
 <% } %>
   ];

--- a/packages/clients/__test__/integration/GeneratedClient.test.ts
+++ b/packages/clients/__test__/integration/GeneratedClient.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert";
 import { HttpMethod, UnknownResponseError } from "@rexeus/typeweaver-core";
 import type { IHttpResponse } from "@rexeus/typeweaver-core";
 import {
+  AccessTokenRequestCommand,
+  createAccessTokenRequest,
   createCreateTodoRequest,
   createDeleteTodoRequest,
   createForbiddenErrorResponse,
@@ -62,6 +64,22 @@ describe("Generated Client", () => {
       const { client } = await setupClientTest();
       const requestData = createCreateTodoRequest();
       const command = new CreateTodoRequestCommand(requestData);
+
+      const response = await client.send(command);
+
+      expect(response.type).toBe("CreateTodoSuccess");
+      assert(response.type === "CreateTodoSuccess");
+      expect(response.statusCode).toBe(201);
+      expect(response.body.title).toBe(requestData.body.title);
+    });
+
+    test("routes generated JSON commands when literal request headers are omitted", async () => {
+      const { client } = await setupClientTest();
+      const requestData = createCreateTodoRequest();
+      const command = new CreateTodoRequestCommand({
+        header: { Authorization: requestData.header.Authorization },
+        body: requestData.body,
+      });
 
       const response = await client.send(command);
 
@@ -138,6 +156,17 @@ describe("Generated Client", () => {
   });
 
   describe("Generated command metadata", () => {
+    test("makes generated headers optional when every required header has a literal default", () => {
+      const requestData = createAccessTokenRequest();
+
+      const command = new AccessTokenRequestCommand({ body: requestData.body });
+
+      expect(command.header).toEqual({
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      });
+    });
+
     test.each([
       {
         scenario: "GET by id",

--- a/packages/clients/__test__/unit/ApiClient.test.ts
+++ b/packages/clients/__test__/unit/ApiClient.test.ts
@@ -663,6 +663,72 @@ describe("ApiClient request serialization", () => {
     expect(getFetchCall(mockFetch).init.body).toBe(JSON.stringify(body));
   });
 
+  test.each([
+    { case: "plain object", body: { title: "Write tests" } },
+    { case: "array", body: [{ title: "Write tests" }] },
+  ])(
+    "adds application/json content-type for JSON-stringified $case bodies",
+    async ({ body }) => {
+      const { mockFetch } = await sendRaw({ method: HttpMethod.POST, body });
+
+      expect(getFetchCall(mockFetch).init.headers).toStrictEqual({
+        "Content-Type": "application/json",
+      });
+    }
+  );
+
+  test("preserves unrelated headers when adding JSON content-type", async () => {
+    const { mockFetch } = await sendRaw({
+      method: HttpMethod.POST,
+      header: { Authorization: "Bearer token" },
+      body: { title: "Write tests" },
+    });
+
+    expect(getFetchCall(mockFetch).init.headers).toStrictEqual({
+      Authorization: "Bearer token",
+      "Content-Type": "application/json",
+    });
+  });
+
+  test.each([
+    { case: "true boolean", body: true, expectedBody: "true" },
+    { case: "positive number", body: 42, expectedBody: "42" },
+    { case: "zero", body: 0, expectedBody: "0" },
+  ])(
+    "adds application/json content-type for JSON-stringified $case bodies",
+    async ({ body, expectedBody }) => {
+      const { mockFetch } = await sendRaw({ method: HttpMethod.POST, body });
+
+      const { init } = getFetchCall(mockFetch);
+      expect(init.body).toBe(expectedBody);
+      expect(init.headers).toStrictEqual({
+        "Content-Type": "application/json",
+      });
+    }
+  );
+
+  test.each([
+    {
+      case: "canonical",
+      header: { "Content-Type": "application/vnd.api+json" } as IHttpHeader,
+    },
+    {
+      case: "lowercase",
+      header: { "content-type": "application/vnd.api+json" } as IHttpHeader,
+    },
+  ])(
+    "preserves user-provided $case content-type for JSON bodies",
+    async ({ header }) => {
+      const { mockFetch } = await sendRaw({
+        method: HttpMethod.POST,
+        header,
+        body: { title: "Write tests" },
+      });
+
+      expect(getFetchCall(mockFetch).init.headers).toStrictEqual(header);
+    }
+  );
+
   test("throws native TypeError for circular object bodies before fetch", async () => {
     const mockFetch = resolvedFetch();
     const client = createClient(mockFetch);
@@ -698,6 +764,30 @@ describe("ApiClient request serialization", () => {
     const { mockFetch } = await sendRaw({ method: HttpMethod.POST, body });
 
     expect(getFetchCall(mockFetch).init.body).toBe(body);
+  });
+
+  test.each([
+    { case: "undefined", body: undefined },
+    { case: "null", body: null },
+    { case: "string", body: "hello" },
+    { case: "Blob", body: new Blob(["hello"], { type: "text/plain" }) },
+    { case: "ArrayBuffer", body: new ArrayBuffer(8) },
+    { case: "Uint8Array", body: new Uint8Array([1, 2, 3]) },
+    { case: "FormData", body: new FormData() },
+    { case: "URLSearchParams", body: new URLSearchParams({ key: "value" }) },
+    {
+      case: "ReadableStream",
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      }),
+    },
+  ])("does not add content-type for $case bodies", async ({ body }) => {
+    const { mockFetch } = await sendRaw({ method: HttpMethod.POST, body });
+
+    expect(getFetchCall(mockFetch).init.headers).toBeUndefined();
   });
 });
 

--- a/packages/clients/__test__/unit/FileClient.test.ts
+++ b/packages/clients/__test__/unit/FileClient.test.ts
@@ -45,6 +45,30 @@ function createJsonMockFetch(
   return createRawMockFetch(status, JSON.stringify(body), headers);
 }
 
+function anUploadCommandWithoutDefaultContentType(props: {
+  readonly authorization: string;
+  readonly fileName: string;
+  readonly body: Blob;
+}): UploadFileRequestCommand {
+  return new UploadFileRequestCommand({
+    header: {
+      Authorization: props.authorization,
+      "X-File-Name": props.fileName,
+    },
+    body: props.body,
+  });
+}
+
+function aMetadataCommandWithoutDefaultAccept(props: {
+  readonly authorization: string;
+  readonly fileId: string;
+}): GetFileMetadataRequestCommand {
+  return new GetFileMetadataRequestCommand({
+    header: { Authorization: props.authorization },
+    param: { fileId: props.fileId },
+  });
+}
+
 function getFetchCall(mockFetch: typeof globalThis.fetch): FetchCallDetails {
   const call = vi.mocked(mockFetch).mock.calls[0];
 
@@ -87,7 +111,7 @@ function expectUnknownResponse(error: unknown, statusCode: number): boolean {
 }
 
 describe("FileClient transport contract", () => {
-  test("sends upload requests as the original binary body", async () => {
+  test("sends upload requests with the generated default Content-Type and original binary body", async () => {
     const metadata = createUploadFileSuccessResponseBody({
       id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
       name: "report.pdf",
@@ -100,14 +124,11 @@ describe("FileClient transport contract", () => {
     const body = new Blob([new Uint8Array([1, 2, 3])], {
       type: "application/octet-stream",
     });
-    const request = createUploadFileRequest({
-      header: {
-        Authorization: "Bearer upload-token",
-        "X-File-Name": "report.pdf",
-      },
+    const command = anUploadCommandWithoutDefaultContentType({
+      authorization: "Bearer upload-token",
+      fileName: "report.pdf",
+      body,
     });
-    request.body = body;
-    const command = new UploadFileRequestCommand(request);
 
     await client.send(command);
 
@@ -120,6 +141,32 @@ describe("FileClient transport contract", () => {
       "X-File-Name": "report.pdf",
     });
     expect(init.body).toBe(body);
+  });
+
+  test("uses generated literal header defaults over runtime command input", async () => {
+    const metadata = createUploadFileSuccessResponseBody();
+    const mockFetch = createJsonMockFetch(201, metadata);
+    const client = createFileClient(mockFetch);
+    const body = new Blob([new Uint8Array([1, 2, 3])], {
+      type: "application/octet-stream",
+    });
+    const command = new UploadFileRequestCommand({
+      header: {
+        Authorization: "Bearer upload-token",
+        "Content-Type": "text/plain",
+        "X-File-Name": "report.pdf",
+      } as unknown as ConstructorParameters<
+        typeof UploadFileRequestCommand
+      >[0]["header"],
+      body,
+    });
+
+    await client.send(command);
+
+    const { init } = getFetchCall(mockFetch);
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/octet-stream",
+    });
   });
 
   test("sends download requests to the encoded file content URL", async () => {
@@ -215,6 +262,30 @@ describe("FileClient transport contract", () => {
       "X-Multi-Value": "a, b",
     });
     expect(init.body).toBeUndefined();
+  });
+
+  test("sends metadata requests with the generated default Accept header when the command input omits it", async () => {
+    const metadata = createGetFileMetadataSuccessResponseBody({
+      id: "01ARZ3NDEKTSV4RRFFQ69G5FBA",
+      name: "default-accept.txt",
+      mimeType: "text/plain",
+      size: 1_024,
+      createdAt: "2025-06-07T08:09:10.000Z",
+    });
+    const mockFetch = createJsonMockFetch(200, metadata);
+    const client = createFileClient(mockFetch);
+    const command = aMetadataCommandWithoutDefaultAccept({
+      authorization: "Bearer metadata-token",
+      fileId: "folder/default accept.txt",
+    });
+
+    await client.send(command);
+
+    const { init } = getFetchCall(mockFetch);
+    expect(init.headers).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer metadata-token",
+    });
   });
 
   test("omits only optional metadata headers explicitly set to undefined", async () => {

--- a/packages/clients/__test__/unit/requestHeaderDefaults.test.ts
+++ b/packages/clients/__test__/unit/requestHeaderDefaults.test.ts
@@ -1,0 +1,81 @@
+import type { NormalizedRequest } from "@rexeus/typeweaver-gen";
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { getRequestHeaderDefaults } from "../../src/requestHeaderDefaults.js";
+
+describe("getRequestHeaderDefaults", () => {
+  test("extracts exact string literal header defaults", () => {
+    const request: NormalizedRequest = {
+      header: z.object({
+        Accept: z.literal("application/json"),
+        Authorization: z.string(),
+        "Content-Type": z.literal("application/json"),
+      }),
+    };
+
+    const defaults = getRequestHeaderDefaults(request);
+
+    expect(defaults).toEqual({
+      entries: [
+        { key: "Accept", value: "application/json" },
+        { key: "Content-Type", value: "application/json" },
+      ],
+      optionalHeaderKeys: ["Accept", "Content-Type"],
+      isHeaderInputOptional: false,
+    });
+  });
+
+  test("marks header input optional when all required headers have defaults", () => {
+    const request: NormalizedRequest = {
+      header: z.object({
+        Accept: z.literal("application/json"),
+        "X-Optional": z.string().optional(),
+      }),
+    };
+
+    const defaults = getRequestHeaderDefaults(request);
+
+    expect(defaults?.isHeaderInputOptional).toBe(true);
+  });
+
+  test("ignores optional-wrapped literals", () => {
+    const request: NormalizedRequest = {
+      header: z.object({ Accept: z.literal("application/json").optional() }),
+    };
+
+    const defaults = getRequestHeaderDefaults(request);
+
+    expect(defaults).toBeUndefined();
+  });
+
+  test.each([
+    {
+      case: "union",
+      schema: z.union([z.literal("application/json"), z.literal("text/plain")]),
+    },
+    {
+      case: "multi-value literal",
+      schema: z.literal(["application/json", "text/plain"]),
+    },
+    { case: "enum", schema: z.enum(["application/json", "text/plain"]) },
+    { case: "non-string literal", schema: z.literal(42) },
+  ])("ignores $case header schemas", ({ schema }) => {
+    const request = {
+      header: z.object({ Accept: schema }),
+    } as NormalizedRequest;
+
+    const defaults = getRequestHeaderDefaults(request);
+
+    expect(defaults).toBeUndefined();
+  });
+
+  test("ignores non-object header schemas", () => {
+    const request = {
+      header: z.record(z.string(), z.string()),
+    } as NormalizedRequest;
+
+    const defaults = getRequestHeaderDefaults(request);
+
+    expect(defaults).toBeUndefined();
+  });
+});

--- a/packages/clients/src/clientGenerator.ts
+++ b/packages/clients/src/clientGenerator.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createJSDocComment } from "@rexeus/typeweaver-gen";
 import type {
   GeneratorContext,
   NormalizedOperation,
@@ -7,6 +8,7 @@ import type {
 } from "@rexeus/typeweaver-gen";
 import { fromZod, print } from "@rexeus/typeweaver-zod-to-ts";
 import { pascalCase } from "polycase";
+import { getRequestHeaderDefaults } from "./requestHeaderDefaults.js";
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -41,6 +43,7 @@ function writeClient(
     return {
       operationId: operation.operationId,
       pascalCaseOperationId: pascalCase(operation.operationId),
+      jsDoc: createJSDocComment(operation.summary, { indentation: "    " }),
       requestFile: `./${path.basename(outputPaths.requestFileName, ".ts")}.js`,
       responseValidatorFile: `./${path.basename(outputPaths.responseValidationFileName, ".ts")}.js`,
       responseFile: `./${path.basename(outputPaths.responseFileName, ".ts")}.js`,
@@ -90,6 +93,7 @@ function writeRequestCommand(
   const paramTsType = request.param ? print(fromZod(request.param)) : undefined;
   const queryTsType = request.query ? print(fromZod(request.query)) : undefined;
   const bodyTsType = request.body ? print(fromZod(request.body)) : undefined;
+  const headerDefaults = getRequestHeaderDefaults(operation.request);
 
   const content = context.renderTemplate(templateFilePath, {
     resourceName,
@@ -103,6 +107,11 @@ function writeRequestCommand(
     paramTsType,
     queryTsType,
     bodyTsType,
+    requestJsDoc: createJSDocComment(operation.summary),
+    headerDefaultEntries: headerDefaults?.entries ?? [],
+    optionalHeaderKeys: headerDefaults?.optionalHeaderKeys ?? [],
+    hasHeaderDefaults: headerDefaults !== undefined,
+    isHeaderInputOptional: headerDefaults?.isHeaderInputOptional ?? false,
     requestFile: `./${path.basename(outputPaths.requestFileName, ".ts")}.js`,
     responseValidatorFile: `./${path.basename(outputPaths.responseValidationFileName, ".ts")}.js`,
     responseFile: `./${path.basename(outputPaths.responseFileName, ".ts")}.js`,

--- a/packages/clients/src/lib/ApiClient.ts
+++ b/packages/clients/src/lib/ApiClient.ts
@@ -30,6 +30,11 @@ export type ApiClientProps = {
   readonly timeoutMs?: number;
 };
 
+type SerializedBody = {
+  readonly body: NonNullable<RequestInit["body"]> | undefined;
+  readonly isJsonSerialized: boolean;
+};
+
 const NETWORK_ERROR_MESSAGES: Readonly<
   Partial<Record<NetworkErrorCode, string>>
 > = {
@@ -119,10 +124,16 @@ export abstract class ApiClient {
     const relativeUrl = this.createUrl(pathWithParam, query);
     const fullUrl = this.buildFullUrl(relativeUrl);
 
+    const serializedBody = this.serializeBody(body);
+    const headers = this.createRequestHeaders(
+      this.flattenHeaders(header),
+      serializedBody.isJsonSerialized
+    );
+
     const response = await this.performFetch(method, fullUrl, {
       method,
-      headers: this.flattenHeaders(header),
-      body: this.serializeBody(body),
+      headers,
+      body: serializedBody.body,
       signal:
         this.timeoutMs !== undefined
           ? AbortSignal.timeout(this.timeoutMs)
@@ -318,14 +329,38 @@ export abstract class ApiClient {
     return flattened;
   }
 
-  private serializeBody(
-    body: unknown
-  ): NonNullable<RequestInit["body"]> | undefined {
-    if (body === null || body === undefined) return undefined;
-    if (typeof body === "string") return body;
+  private createRequestHeaders(
+    headers: Record<string, string> | undefined,
+    isJsonSerialized: boolean
+  ): Record<string, string> | undefined {
+    if (!isJsonSerialized) return headers;
+
+    const requestHeaders = headers ? { ...headers } : {};
+    if (!this.hasContentTypeHeader(requestHeaders)) {
+      requestHeaders["Content-Type"] = "application/json";
+    }
+    return requestHeaders;
+  }
+
+  private hasContentTypeHeader(headers: Record<string, string>): boolean {
+    return Object.keys(headers).some(
+      key => key.toLowerCase() === "content-type"
+    );
+  }
+
+  private serializeBody(body: unknown): SerializedBody {
+    if (body === null || body === undefined) {
+      return { body: undefined, isJsonSerialized: false };
+    }
+    if (typeof body === "string") {
+      return { body, isJsonSerialized: false };
+    }
     if (this.isNativeBody(body))
-      return body as NonNullable<RequestInit["body"]>;
-    return JSON.stringify(body);
+      return {
+        body: body as NonNullable<RequestInit["body"]>,
+        isJsonSerialized: false,
+      };
+    return { body: JSON.stringify(body), isJsonSerialized: true };
   }
 
   private isNativeBody(body: unknown): boolean {

--- a/packages/clients/src/requestHeaderDefaults.ts
+++ b/packages/clients/src/requestHeaderDefaults.ts
@@ -1,0 +1,68 @@
+import type { NormalizedRequest } from "@rexeus/typeweaver-gen";
+import type { ZodObject, ZodType } from "zod";
+
+export type RequestHeaderDefaultEntry = {
+  readonly key: string;
+  readonly value: string;
+};
+
+export type RequestHeaderDefaults = {
+  readonly entries: readonly RequestHeaderDefaultEntry[];
+  readonly optionalHeaderKeys: readonly string[];
+  readonly isHeaderInputOptional: boolean;
+};
+
+type ZodObjectWithShape = ZodObject<Record<string, ZodType>> & {
+  readonly shape: Record<string, ZodType>;
+};
+
+function getSchemaType(schema: ZodType): string | undefined {
+  return schema.def?.type ?? schema._def?.type;
+}
+
+function isZodObject(schema: ZodType): schema is ZodObjectWithShape {
+  return getSchemaType(schema) === "object" && "shape" in schema;
+}
+
+function getStringLiteralValue(schema: ZodType): string | undefined {
+  if (getSchemaType(schema) !== "literal") return undefined;
+
+  const literalSchema = schema as { readonly values?: ReadonlySet<unknown> };
+  if (literalSchema.values?.size !== 1) return undefined;
+
+  const [value] = literalSchema.values;
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRequiredSchema(schema: ZodType): boolean {
+  return !schema.isOptional();
+}
+
+export function getRequestHeaderDefaults(
+  request: NormalizedRequest | undefined
+): RequestHeaderDefaults | undefined {
+  const header = request?.header;
+  if (!header || !isZodObject(header)) return undefined;
+
+  const entries = Object.entries(header.shape)
+    .flatMap(([key, schema]) => {
+      const value = getStringLiteralValue(schema);
+      return value === undefined ? [] : [{ key, value }];
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  if (entries.length === 0) return undefined;
+
+  const defaultedHeaderKeys = new Set(entries.map(entry => entry.key));
+  const requiredHeaderKeys = Object.entries(header.shape)
+    .filter(([, schema]) => isRequiredSchema(schema))
+    .map(([key]) => key);
+
+  return {
+    entries,
+    optionalHeaderKeys: entries.map(entry => entry.key),
+    isHeaderInputOptional: requiredHeaderKeys.every(key =>
+      defaultedHeaderKeys.has(key)
+    ),
+  };
+}

--- a/packages/clients/src/templates/Client.ejs
+++ b/packages/clients/src/templates/Client.ejs
@@ -29,7 +29,8 @@ export class <%= pascalCaseEntityName %>Client extends ApiClient {
     }
 
     <% for (const operation of operations) { %>
-    public async send(command: <%= operation.pascalCaseOperationId %>RequestCommand): Promise<<%= operation.pascalCaseOperationId %>Response>;
+    <% if (operation.jsDoc) { %><%- operation.jsDoc %>
+    <% } %>public async send(command: <%= operation.pascalCaseOperationId %>RequestCommand): Promise<<%= operation.pascalCaseOperationId %>Response>;
     <% } %>
     public async send(command: <%= pascalCaseEntityName %>RequestCommands): Promise<<%= pascalCaseEntityName %>Responses> {
         const response = await this.execute(command);

--- a/packages/clients/src/templates/RequestCommand.ejs
+++ b/packages/clients/src/templates/RequestCommand.ejs
@@ -22,8 +22,20 @@ import type { <%= pascalCaseOperationId %>Response } from "<%= responseFile %>";
 
 const definition = getOperationDefinition(spec, "<%= resourceName %>", "<%= operationId %>");
 const responseValidator = new <%= pascalCaseOperationId %>ResponseValidator();
+<% if (hasHeaderDefaults) { %>
+const defaultHeader = {
+<% for (const entry of headerDefaultEntries) { %>
+    <%- JSON.stringify(entry.key) %>: <%- JSON.stringify(entry.value) %>,
+<% } %>
+} as const;
 
-export class <%= pascalCaseOperationId %>RequestCommand extends RequestCommand implements I<%= pascalCaseOperationId %>Request {
+export type <%= pascalCaseOperationId %>RequestCommandInput = Omit<I<%= pascalCaseOperationId %>Request, "method" | "path" | "header"> & {
+    readonly header<%= isHeaderInputOptional ? "?" : "" %>: Omit<I<%= pascalCaseOperationId %>RequestHeader, <%- optionalHeaderKeys.map(key => JSON.stringify(key)).join(" | ") %>> & Partial<Pick<I<%= pascalCaseOperationId %>RequestHeader, <%- optionalHeaderKeys.map(key => JSON.stringify(key)).join(" | ") %>>>;
+};
+<% } %>
+
+<% if (requestJsDoc) { %><%- requestJsDoc %>
+<% } %>export class <%= pascalCaseOperationId %>RequestCommand extends RequestCommand implements I<%= pascalCaseOperationId %>Request {
     public override readonly operationId = definition.operationId;
     public override readonly method = definition.method as HttpMethod.<%= method %>;
     public override readonly path = definition.path;
@@ -33,11 +45,11 @@ export class <%= pascalCaseOperationId %>RequestCommand extends RequestCommand i
     public <%= queryTsType ? `override` : `declare` %> readonly query: <%= queryTsType ? `I${pascalCaseOperationId}RequestQuery` : `undefined` %>;
     public <%= bodyTsType ? `override` : `declare` %> readonly body: <%= bodyTsType ? `I${pascalCaseOperationId}RequestBody` : `undefined` %>;
 
-    public constructor(input: Omit<I<%= pascalCaseOperationId %>Request, "method" | "path">) {
+    public constructor(input: <%- hasHeaderDefaults ? `${pascalCaseOperationId}RequestCommandInput` : `Omit<I${pascalCaseOperationId}Request, "method" | "path">` %>) {
         super();
 
         <% if (headerTsType) { %>
-        this.header = input.header;
+        this.header = <% if (hasHeaderDefaults) { %>{ ...input.header, ...defaultHeader }<% } else { %>input.header<% } %>;
         <% } %>
 
         <% if (paramTsType) { %>

--- a/packages/core/__test__/unit/isTypedHttpResponse.test.ts
+++ b/packages/core/__test__/unit/isTypedHttpResponse.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { HttpStatusCode, isTypedHttpResponse } from "../../src/index.js";
+import {
+  HttpStatusCode,
+  isTypedHttpResponse,
+  toHttpResponse,
+} from "../../src/index.js";
 import { TestApplicationError, TestObjectTrapError } from "../errors/index.js";
 import type { ITypedHttpResponse } from "../../src/index.js";
 
@@ -156,6 +160,38 @@ describe("isTypedHttpResponse", () => {
     };
 
     expect(isTypedHttpResponse(response)).toBe(true);
+  });
+
+  test("accepts a typed HTTP response without header when the header type is undefined", () => {
+    const response = {
+      type: "Success",
+      statusCode: HttpStatusCode.OK,
+      body: { ok: true },
+    } satisfies ITypedHttpResponse<
+      "Success",
+      HttpStatusCode.OK,
+      undefined,
+      { readonly ok: true }
+    >;
+
+    expect(isTypedHttpResponse(response)).toBe(true);
+  });
+
+  test("normalizes an omitted typed HTTP response header to undefined", () => {
+    const response = {
+      type: "Success",
+      statusCode: HttpStatusCode.OK,
+      body: { ok: true },
+    } satisfies ITypedHttpResponse<
+      "Success",
+      HttpStatusCode.OK,
+      undefined,
+      { readonly ok: true }
+    >;
+
+    const normalized = toHttpResponse(response);
+
+    expect(normalized.header).toBeUndefined();
   });
 
   test("accepts a typed HTTP response with explicit empty payload fields", () => {

--- a/packages/core/src/HttpResponse.ts
+++ b/packages/core/src/HttpResponse.ts
@@ -23,6 +23,9 @@ export type ITypedHttpResponse<
 > = {
   readonly type: TypeName;
   readonly statusCode: StatusCode;
-  readonly header: Header;
   readonly body: Body;
-};
+} & ([Header] extends [undefined]
+  ? { readonly header?: undefined }
+  : [ITypedHttpResponseHeader] extends [Header]
+    ? { readonly header?: Header }
+    : { readonly header: Header });

--- a/packages/core/src/HttpResponseNormalization.ts
+++ b/packages/core/src/HttpResponseNormalization.ts
@@ -70,9 +70,7 @@ export const isTypedHttpResponse = (
   );
 };
 
-export const toHttpHeader = (
-  header: ITypedHttpResponse["header"]
-): IHttpHeader => {
+export const toHttpHeader = (header: ITypedHttpResponseHeader): IHttpHeader => {
   if (!header) return undefined;
 
   const normalizedHeader: NonNullable<IHttpHeader> = {};

--- a/packages/gen/__test__/jsdoc.test.ts
+++ b/packages/gen/__test__/jsdoc.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { createJSDocComment } from "../src/index.js";
+
+describe("createJSDocComment", () => {
+  test.each([
+    { case: "undefined", text: undefined },
+    { case: "empty", text: "" },
+    { case: "blank", text: " \t\n\r\n " },
+  ])("returns undefined for $case input", ({ text }) => {
+    const comment = createJSDocComment(text);
+
+    expect(comment).toBeUndefined();
+  });
+
+  test("formats single-line text as a JSDoc block", () => {
+    const comment = createJSDocComment("Create a todo");
+
+    expect(comment).toBe("/**\n * Create a todo\n */");
+  });
+
+  test("preserves internal multiline formatting while trimming outer blank lines", () => {
+    const comment = createJSDocComment(
+      "\r\nFirst line\r\n\r\n  Indented line\r\n"
+    );
+
+    expect(comment).toBe("/**\n * First line\n * \n *   Indented line\n */");
+  });
+
+  test("applies indentation before each emitted line", () => {
+    const comment = createJSDocComment("Indented", { indentation: "  " });
+
+    expect(comment).toBe("  /**\n   * Indented\n   */");
+  });
+
+  test("sanitizes block comment terminators", () => {
+    const comment = createJSDocComment("Do not close */ the comment");
+
+    expect(comment).toBe("/**\n * Do not close *\\/ the comment\n */");
+  });
+});

--- a/packages/gen/src/helpers/jsdoc.ts
+++ b/packages/gen/src/helpers/jsdoc.ts
@@ -1,0 +1,27 @@
+export type CreateJSDocCommentOptions = {
+  readonly indentation?: string;
+};
+
+const BLOCK_COMMENT_END_PATTERN = /\*\//g;
+const LINE_BREAK_PATTERN = /\r\n?/g;
+
+export function createJSDocComment(
+  text: string | undefined,
+  options: CreateJSDocCommentOptions = {}
+): string | undefined {
+  const normalizedText = text?.replace(LINE_BREAK_PATTERN, "\n");
+  const trimmedText = normalizedText?.trim();
+
+  if (!trimmedText) return undefined;
+
+  const indentation = options.indentation ?? "";
+  const lines = trimmedText
+    .replace(BLOCK_COMMENT_END_PATTERN, "*\\/")
+    .split("\n");
+
+  return [
+    `${indentation}/**`,
+    ...lines.map(line => `${indentation} * ${line}`),
+    `${indentation} */`,
+  ].join("\n");
+}

--- a/packages/gen/src/index.ts
+++ b/packages/gen/src/index.ts
@@ -2,6 +2,7 @@ export * from "./errors/index.js";
 export * from "./normalized/index.js";
 export * from "./plugins/index.js";
 export * from "./helpers/namingUtils.js";
+export * from "./helpers/jsdoc.js";
 export * from "./helpers/path.js";
 export * from "./helpers/routePath.js";
 export * from "./helpers/routeSort.js";

--- a/packages/hono/src/honoRouterGenerator.ts
+++ b/packages/hono/src/honoRouterGenerator.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { HttpMethod } from "@rexeus/typeweaver-core";
-import { compareRoutes, relative } from "@rexeus/typeweaver-gen";
+import {
+  compareRoutes,
+  createJSDocComment,
+  relative,
+} from "@rexeus/typeweaver-gen";
 import type {
   GeneratorContext,
   NormalizedOperation,
@@ -48,11 +52,13 @@ function createOperationData(operation: NormalizedOperation) {
   const operationId = operation.operationId;
   const className = pascalCase(operationId);
   const handlerName = `handle${className}Request`;
+  const jsDoc = createJSDocComment(operation.summary, { indentation: "  " });
 
   return {
     operationId,
     className,
     handlerName,
+    ...(jsDoc ? { jsDoc } : {}),
     method: operation.method,
     path: operation.path,
   };

--- a/packages/hono/src/templates/HonoRouter.ejs
+++ b/packages/hono/src/templates/HonoRouter.ejs
@@ -17,7 +17,8 @@ import { <%- operation.className %>ResponseValidator } from "./<%- operation.cla
 
 export type Hono<%- pascalCaseEntityName %>ApiHandler = {
 <% for (const operation of operations) { %>
-  <%- operation.handlerName %>: HonoRequestHandler<I<%- operation.className %>Request, <%- operation.className %>Response>;
+<% if (operation.jsDoc) { %><%- operation.jsDoc %>
+<% } %>  <%- operation.handlerName %>: HonoRequestHandler<I<%- operation.className %>Request, <%- operation.className %>Response>;
 <% } %>
 };
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -294,10 +294,10 @@ Each middleware is documented in detail — click the links above.
 
 `TypeweaverApp` accepts an optional options object:
 
-| Option        | Type                       | Default            | Description                                                 |
-| ------------- | -------------------------- | ------------------ | ----------------------------------------------------------- |
-| `maxBodySize` | `number`                   | `1_048_576` (1 MB) | Max request body size in bytes. Exceeding returns `413`.    |
-| `onError`     | `(error: unknown) => void` | `console.error`    | Error callback. Falls back to `console.error` if it throws. |
+| Option        | Type                       | Default            | Description                                                                                                           |
+| ------------- | -------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `maxBodySize` | `number`                   | `1_048_576` (1 MB) | Max request body size in bytes. Exceeding returns `413`.                                                              |
+| `onError`     | `(error: unknown) => void` | `console.error`    | Reports errors from the default unknown handler and top-level safety net. Falls back to `console.error` if it throws. |
 
 ```ts
 const app = new TypeweaverApp({
@@ -325,7 +325,7 @@ errors fall through to the next handler in the chain (except `handleResponseVali
 `false` means the invalid response is returned as-is — validation still runs for field stripping,
 but invalid responses pass through unchanged). When set to a function, it receives the error and
 `ServerContext` and must return an `IHttpResponse`. If a custom error handler throws, the framework
-catches the exception and falls through gracefully to the next handler.
+reports that handler failure through `onError` and falls through gracefully to the next handler.
 
 ### 🚨 Error Handling
 
@@ -430,6 +430,12 @@ new UserRouter({
   },
 });
 ```
+
+The default unknown-error handler calls `onError` before returning a sanitized 500 response. A
+custom `handleUnknownErrors` function replaces that default reporting strategy; if you need logging
+or metrics with a custom unknown handler, perform that reporting inside the custom handler. If the
+custom unknown handler throws, Typeweaver reports the handler failure through `onError` and then
+falls through to the top-level safety net.
 
 ### 📋 Error Responses
 

--- a/packages/server/__test__/unit/TypeweaverApp.test.ts
+++ b/packages/server/__test__/unit/TypeweaverApp.test.ts
@@ -1,6 +1,7 @@
 import {
   badRequestDefaultError,
   HttpMethod,
+  HttpStatusCode,
   internalServerErrorDefaultError,
   methodNotAllowedDefaultError,
   notFoundDefaultError,
@@ -90,6 +91,40 @@ const invalidResponseValidator: IResponseValidator = {
   }),
 };
 
+function aConflictTypedResponse(): ITypedHttpResponse<
+  "ConflictError",
+  HttpStatusCode.CONFLICT,
+  undefined,
+  { readonly code: string }
+> {
+  return {
+    type: "ConflictError",
+    statusCode: HttpStatusCode.CONFLICT,
+    body: { code: "CONFLICT" },
+  };
+}
+
+function aPassThroughResponseValidator(): IResponseValidator {
+  return {
+    validate: response => response,
+    safeValidate: response => ({ isValid: true, data: response }),
+  };
+}
+
+function aValidatorThatMarksResponsesAsValidated(): IResponseValidator {
+  return {
+    validate: response => response,
+    safeValidate: response => ({
+      isValid: true,
+      data: {
+        ...response,
+        header: { "x-response-source": "validator" },
+        body: { source: "validated" },
+      },
+    }),
+  };
+}
+
 type ConsoleErrorSpy = {
   mockRestore: () => void;
 };
@@ -98,6 +133,15 @@ type TestHandlers = {
   handleGetTodos: RequestHandler;
   handleCreateTodo: RequestHandler;
   handleGetTodo: RequestHandler;
+};
+
+type TypedResponseValidationAppOptions = {
+  readonly typedResponse?: ITypedHttpResponse;
+  readonly responseValidator?: IResponseValidator;
+  readonly handleHttpResponseErrors?: TypeweaverRouterOptions<TestHandlers>["handleHttpResponseErrors"];
+  readonly handleUnknownErrors?: TypeweaverRouterOptions<TestHandlers>["handleUnknownErrors"];
+  readonly handleResponseValidationErrors?: TypeweaverRouterOptions<TestHandlers>["handleResponseValidationErrors"];
+  readonly onError?: TypeweaverAppOptions["onError"];
 };
 
 class TestRouter extends TypeweaverRouter<TestHandlers> {
@@ -326,6 +370,38 @@ function createResponseValidatingApp(
     requestHandlers: defaultHandlers(handlerOverrides),
     ...routerOptions,
   });
+  app.route(router);
+  return app;
+}
+
+function createTypedResponseValidationApp({
+  typedResponse = aConflictTypedResponse(),
+  responseValidator = aPassThroughResponseValidator(),
+  handleHttpResponseErrors,
+  handleUnknownErrors,
+  handleResponseValidationErrors,
+  onError,
+}: TypedResponseValidationAppOptions = {}): TypeweaverApp {
+  const app = new TypeweaverApp(
+    onError === undefined ? undefined : { onError }
+  );
+  const router = new CustomResponseValidatingRouter({
+    validateRequests: false,
+    responseValidator,
+    requestHandlers: defaultHandlers({
+      handleGetTodos: async () => {
+        throw typedResponse;
+      },
+    }),
+    ...(handleHttpResponseErrors === undefined
+      ? {}
+      : { handleHttpResponseErrors }),
+    ...(handleUnknownErrors === undefined ? {} : { handleUnknownErrors }),
+    ...(handleResponseValidationErrors === undefined
+      ? {}
+      : { handleResponseValidationErrors }),
+  });
+
   app.route(router);
   return app;
 }
@@ -1002,6 +1078,86 @@ describe("TypeweaverApp", () => {
       const data = await expectJson(res, 500);
       expect(data.custom).toBe(true);
       expect(data.message).toBe("Boom");
+    });
+
+    test("does not call onError when a custom unknown error handler returns a response", async () => {
+      const onError = vi.fn();
+      const app = createApp(
+        {
+          handleUnknownErrors: error => ({
+            statusCode: 500,
+            body: {
+              code: "CUSTOM_UNKNOWN",
+              message: error instanceof Error ? error.message : "Unknown",
+            },
+          }),
+        },
+        {
+          handleGetTodos: async () => {
+            throw new TestApplicationError("custom handler owns reporting");
+          },
+        },
+        { onError }
+      );
+
+      const res = await app.fetch(get("/todos"));
+
+      const data = await expectJson(res, 500);
+      expect(data).toEqual({
+        code: "CUSTOM_UNKNOWN",
+        message: "custom handler owns reporting",
+      });
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    test("reports custom unknown handler failures to onError", async () => {
+      const onError = vi.fn();
+      const handlerFailure = new TestApplicationError(
+        "custom unknown handler failed"
+      );
+      const app = createApp(
+        {
+          handleUnknownErrors: () => {
+            throw handlerFailure;
+          },
+        },
+        {
+          handleGetTodos: async () => {
+            throw new TestApplicationError("unexpected failure");
+          },
+        },
+        { onError }
+      );
+
+      const res = await app.fetch(get("/todos"));
+
+      await expectErrorResponse(res, 500, "INTERNAL_SERVER_ERROR");
+      expect(onError).toHaveBeenCalledWith(handlerFailure);
+    });
+
+    test("falls through to the safety net when the custom unknown handler throws", async () => {
+      const onError = vi.fn();
+      const routeFailure = new TestApplicationError("unexpected failure");
+      const app = createApp(
+        {
+          handleUnknownErrors: () => {
+            throw new TestApplicationError("custom unknown handler failed");
+          },
+        },
+        {
+          handleGetTodos: async () => {
+            throw routeFailure;
+          },
+        },
+        { onError }
+      );
+
+      const res = await app.fetch(get("/todos"));
+
+      await expectErrorResponse(res, 500, "INTERNAL_SERVER_ERROR");
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: routeFailure.message })
+      );
     });
 
     test("should call onError for errors that escape to the safety net", async () => {
@@ -1773,43 +1929,168 @@ describe("TypeweaverApp", () => {
       expect(onError).toHaveBeenCalledWith(handlerFailure);
     });
 
-    test("validates a thrown typed HTTP response before the HTTP response handler handles it", async () => {
-      const typedInvalidResponse = {
-        type: "ConflictError",
-        statusCode: 409,
-        header: {},
-        body: { code: "CONFLICT" },
-      } satisfies ITypedHttpResponse;
-      const app = createResponseValidatingApp(
-        {
-          handleHttpResponseErrors: () => ({
-            statusCode: 409,
-            body: { code: "HTTP_RESPONSE_HANDLER" },
-          }),
-          handleResponseValidationErrors: (_error, response, ctx) => ({
-            statusCode: 422,
-            body: {
-              code: "INVALID_THROWN_RESPONSE",
-              originalStatus: response.statusCode,
-              operationId: ctx.route?.operationId,
-            },
-          }),
-        },
-        {
-          handleGetTodos: async () => {
-            throw typedInvalidResponse;
-          },
-        }
+    test("calls the custom HTTP response handler for thrown typed responses when response validation is enabled", async () => {
+      const typedResponse = aConflictTypedResponse();
+      const httpResponseHandler = vi.fn(() => ({
+        statusCode: 200,
+        body: { handled: true },
+      }));
+      const app = createTypedResponseValidationApp({
+        typedResponse,
+        handleHttpResponseErrors: httpResponseHandler,
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      const data = await expectJson(res, 200);
+      expect(data).toEqual({ handled: true });
+      expect(httpResponseHandler).toHaveBeenCalledWith(
+        typedResponse,
+        expect.anything()
       );
+    });
+
+    test("validates the transformed typed response handler result before sending it", async () => {
+      const app = createTypedResponseValidationApp({
+        responseValidator: aValidatorThatMarksResponsesAsValidated(),
+        handleHttpResponseErrors: () => ({
+          statusCode: 200,
+          header: { "x-response-source": "handler" },
+          body: { source: "handler", stripped: true },
+        }),
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      const data = await expectJson(res, 200);
+      expect(data).toEqual({ source: "validated" });
+      expect(res.headers.get("x-response-source")).toBe("validator");
+    });
+
+    test("invokes the response validation handler when a transformed thrown typed response is invalid", async () => {
+      const app = createTypedResponseValidationApp({
+        responseValidator: invalidResponseValidator,
+        handleHttpResponseErrors: () => ({
+          statusCode: 409,
+          body: { code: "HTTP_RESPONSE_HANDLER" },
+        }),
+        handleResponseValidationErrors: (_error, response, ctx) => ({
+          statusCode: 422,
+          body: {
+            code: "INVALID_TRANSFORMED_RESPONSE",
+            originalStatus: response.statusCode,
+            operationId: ctx.route?.operationId,
+          },
+        }),
+      });
 
       const res = await app.fetch(get("/todos"));
 
       const data = await expectJson(res, 422);
       expect(data).toEqual({
-        code: "INVALID_THROWN_RESPONSE",
+        code: "INVALID_TRANSFORMED_RESPONSE",
         originalStatus: 409,
         operationId: "listTodos",
       });
+    });
+
+    test("falls through to the unknown handler when a typed response handler throws", async () => {
+      const typedResponse = aConflictTypedResponse();
+      const onError = vi.fn();
+      const handlerFailure = new TestApplicationError(
+        "typed response handler failed"
+      );
+      const unknownHandler = vi.fn(() => ({
+        statusCode: 500,
+        body: { code: "CUSTOM_UNKNOWN", message: "typed response escaped" },
+      }));
+      const app = createTypedResponseValidationApp({
+        typedResponse,
+        handleHttpResponseErrors: () => {
+          throw handlerFailure;
+        },
+        handleUnknownErrors: unknownHandler,
+        onError,
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      const data = await expectJson(res, 500);
+      expect(data).toEqual({
+        code: "CUSTOM_UNKNOWN",
+        message: "typed response escaped",
+      });
+      expect(onError).toHaveBeenCalledWith(handlerFailure);
+      expect(unknownHandler).toHaveBeenCalledWith(
+        typedResponse,
+        expect.anything()
+      );
+    });
+
+    test("strips HEAD bodies after validating transformed thrown typed responses", async () => {
+      const app = createTypedResponseValidationApp({
+        responseValidator: aValidatorThatMarksResponsesAsValidated(),
+        handleHttpResponseErrors: () => ({
+          statusCode: 200,
+          header: { "x-response-source": "handler" },
+          body: { source: "handler" },
+        }),
+      });
+
+      const res = await app.fetch(head("/todos"));
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-response-source")).toBe("validator");
+      await expectNoBody(res);
+    });
+
+    test("returns invalid transformed typed responses when response validation handling is disabled", async () => {
+      const app = createTypedResponseValidationApp({
+        responseValidator: invalidResponseValidator,
+        handleHttpResponseErrors: () => ({
+          statusCode: 409,
+          header: { "x-response-source": "handler" },
+          body: { code: "HTTP_RESPONSE_HANDLER" },
+        }),
+        handleResponseValidationErrors: false,
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      const data = await expectJson(res, 409);
+      expect(data).toEqual({ code: "HTTP_RESPONSE_HANDLER" });
+      expect(res.headers.get("x-response-source")).toBe("handler");
+    });
+
+    test("falls through to the unknown handler for thrown typed responses when HTTP response handling is disabled with response validation enabled", async () => {
+      const unknownHandler = vi.fn(() => ({
+        statusCode: 500,
+        body: { code: "CUSTOM_UNKNOWN" },
+      }));
+      const app = createTypedResponseValidationApp({
+        handleHttpResponseErrors: false,
+        handleUnknownErrors: unknownHandler,
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      await expectErrorResponse(res, 500, "CUSTOM_UNKNOWN");
+      expect(unknownHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "ConflictError", statusCode: 409 }),
+        expect.anything()
+      );
+    });
+
+    test("keeps default typed response handling silent for onError when response validation is enabled", async () => {
+      const onError = vi.fn();
+      const app = createTypedResponseValidationApp({
+        onError,
+      });
+
+      const res = await app.fetch(get("/todos"));
+
+      await expectErrorResponse(res, 409, "CONFLICT");
+      expect(onError).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/server/__test__/unit/routerGenerator.test.ts
+++ b/packages/server/__test__/unit/routerGenerator.test.ts
@@ -15,6 +15,7 @@ type RouterOperationData = {
   readonly path: string;
   readonly handlerName: string;
   readonly className: string;
+  readonly jsDoc?: string;
 };
 
 type RouterTemplateData = {
@@ -215,6 +216,20 @@ describe("RouterGenerator", () => {
       assert(result[0]);
       expect(result[0].className).toBe("UpdateTodoStatus");
       expect(result[0].handlerName).toBe("handleUpdateTodoStatusRequest");
+    });
+
+    test("emits sanitized operation summaries as handler JSDoc", () => {
+      const result = getOperationOrder([
+        {
+          ...anOperation("createTodo", HttpMethod.POST, "/todos"),
+          summary: "Create todo */ safely",
+        },
+      ]);
+
+      assert(result[0]);
+      expect(result[0].jsDoc).toBe(
+        "  /**\n   * Create todo *\\/ safely\n   */"
+      );
     });
 
     test("preserves method path and operation id associations after sorting", () => {

--- a/packages/server/src/lib/TypeweaverApp.ts
+++ b/packages/server/src/lib/TypeweaverApp.ts
@@ -252,16 +252,6 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
           routeCtx
         );
       } catch (error) {
-        if (
-          isTypedHttpResponse(error) &&
-          match.route.routerConfig.validateResponses
-        ) {
-          return await this.validateResponse(
-            match.route,
-            toHttpResponse(error),
-            routeCtx
-          );
-        }
         return this.handleError(error, routeCtx, match.route);
       }
     }
@@ -399,7 +389,13 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
         const response = await this.safelyExecuteErrorHandler(() =>
           handler(error, ctx)
         );
-        if (response) return response;
+        if (response) {
+          return await this.validateResponse(
+            route,
+            normalizeHttpResponse(response),
+            ctx
+          );
+        }
       }
     }
 

--- a/packages/server/src/routerGenerator.ts
+++ b/packages/server/src/routerGenerator.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { HttpMethod } from "@rexeus/typeweaver-core";
-import { compareRoutes, relative } from "@rexeus/typeweaver-gen";
+import {
+  compareRoutes,
+  createJSDocComment,
+  relative,
+} from "@rexeus/typeweaver-gen";
 import type {
   GeneratorContext,
   NormalizedOperation,
@@ -22,6 +26,7 @@ type OperationData = {
   readonly operationId: string;
   readonly className: string;
   readonly handlerName: string;
+  readonly jsDoc?: string;
   readonly method: string;
   readonly path: string;
 };
@@ -75,11 +80,13 @@ function writeRouter(
 function createOperationData(operation: NormalizedOperation): OperationData {
   const operationId = operation.operationId;
   const className = pascalCase(operationId);
+  const jsDoc = createJSDocComment(operation.summary, { indentation: "  " });
 
   return {
     operationId,
     className,
     handlerName: `handle${className}Request`,
+    ...(jsDoc ? { jsDoc } : {}),
     method: operation.method,
     path: operation.path,
   };

--- a/packages/server/src/templates/Router.ejs
+++ b/packages/server/src/templates/Router.ejs
@@ -18,7 +18,8 @@ export type Server<%- pascalCaseEntityName %>ApiHandler<
   TState extends Record<string, unknown> = Record<string, unknown>,
 > = {
 <% for (const operation of operations) { %>
-  <%- operation.handlerName %>: RequestHandler<I<%- operation.className %>Request, <%- operation.className %>Response, TState>;
+<% if (operation.jsDoc) { %><%- operation.jsDoc %>
+<% } %>  <%- operation.handlerName %>: RequestHandler<I<%- operation.className %>Request, <%- operation.className %>Response, TState>;
 <% } %>
 };
 

--- a/packages/test-utils/src/test-project/output/account/AccountClient.ts
+++ b/packages/test-utils/src/test-project/output/account/AccountClient.ts
@@ -20,6 +20,9 @@ export class AccountClient extends ApiClient {
     super(props);
   }
 
+  /**
+   * Register new account
+   */
   public async send(command: RegisterAccountRequestCommand): Promise<RegisterAccountResponse>;
 
   public async send(command: AccountRequestCommands): Promise<AccountResponses> {

--- a/packages/test-utils/src/test-project/output/account/AccountHono.ts
+++ b/packages/test-utils/src/test-project/output/account/AccountHono.ts
@@ -19,6 +19,9 @@ import type { RegisterAccountResponse } from "./RegisterAccountResponse.js";
 import { RegisterAccountResponseValidator } from "./RegisterAccountResponseValidator.js";
 
 export type HonoAccountApiHandler = {
+  /**
+   * Register new account
+   */
   handleRegisterAccountRequest: HonoRequestHandler<
     IRegisterAccountRequest,
     RegisterAccountResponse

--- a/packages/test-utils/src/test-project/output/account/AccountHttpApiRoutes.ts
+++ b/packages/test-utils/src/test-project/output/account/AccountHttpApiRoutes.ts
@@ -12,6 +12,9 @@ import { type AwsHttpApiGatewayRoute, AwsHttpApiGatewayRoutes } from "../lib/aws
 export class AccountHttpApiRoutes extends AwsHttpApiGatewayRoutes {
   private routes: AwsHttpApiGatewayRoute[] = [
     {
+      /**
+       * POST: Register new account
+       */
       path: "/accounts",
       methods: [HttpMethod.POST],
     },

--- a/packages/test-utils/src/test-project/output/account/AccountRouter.ts
+++ b/packages/test-utils/src/test-project/output/account/AccountRouter.ts
@@ -21,6 +21,9 @@ import { RegisterAccountResponseValidator } from "./RegisterAccountResponseValid
 export type ServerAccountApiHandler<
   TState extends Record<string, unknown> = Record<string, unknown>,
 > = {
+  /**
+   * Register new account
+   */
   handleRegisterAccountRequest: RequestHandler<
     IRegisterAccountRequest,
     RegisterAccountResponse,

--- a/packages/test-utils/src/test-project/output/account/RegisterAccountRequest.ts
+++ b/packages/test-utils/src/test-project/output/account/RegisterAccountRequest.ts
@@ -20,6 +20,9 @@ export type IRegisterAccountRequestBody = {
   password: string;
 };
 
+/**
+ * Register new account
+ */
 export type IRegisterAccountRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/account/RegisterAccountRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/account/RegisterAccountRequestCommand.ts
@@ -26,6 +26,23 @@ import type { RegisterAccountResponse } from "./RegisterAccountResponse.js";
 const definition = getOperationDefinition(spec, "account", "RegisterAccount");
 const responseValidator = new RegisterAccountResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type RegisterAccountRequestCommandInput = Omit<
+  IRegisterAccountRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header?: Omit<IRegisterAccountRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IRegisterAccountRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Register new account
+ */
 export class RegisterAccountRequestCommand
   extends RequestCommand
   implements IRegisterAccountRequest
@@ -39,10 +56,10 @@ export class RegisterAccountRequestCommand
   declare public readonly query: undefined;
   public override readonly body: IRegisterAccountRequestBody;
 
-  public constructor(input: Omit<IRegisterAccountRequest, "method" | "path">) {
+  public constructor(input: RegisterAccountRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.body = input.body;
   }

--- a/packages/test-utils/src/test-project/output/auth/AccessTokenRequest.ts
+++ b/packages/test-utils/src/test-project/output/auth/AccessTokenRequest.ts
@@ -20,6 +20,9 @@ export type IAccessTokenRequestBody = {
   password: string;
 };
 
+/**
+ * Get access token by email and password
+ */
 export type IAccessTokenRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/auth/AccessTokenRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/auth/AccessTokenRequestCommand.ts
@@ -26,6 +26,23 @@ import type { AccessTokenResponse } from "./AccessTokenResponse.js";
 const definition = getOperationDefinition(spec, "auth", "AccessToken");
 const responseValidator = new AccessTokenResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type AccessTokenRequestCommandInput = Omit<
+  IAccessTokenRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header?: Omit<IAccessTokenRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IAccessTokenRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Get access token by email and password
+ */
 export class AccessTokenRequestCommand extends RequestCommand implements IAccessTokenRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -36,10 +53,10 @@ export class AccessTokenRequestCommand extends RequestCommand implements IAccess
   declare public readonly query: undefined;
   public override readonly body: IAccessTokenRequestBody;
 
-  public constructor(input: Omit<IAccessTokenRequest, "method" | "path">) {
+  public constructor(input: AccessTokenRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.body = input.body;
   }

--- a/packages/test-utils/src/test-project/output/auth/AuthClient.ts
+++ b/packages/test-utils/src/test-project/output/auth/AuthClient.ts
@@ -23,8 +23,14 @@ export class AuthClient extends ApiClient {
     super(props);
   }
 
+  /**
+   * Get access token by email and password
+   */
   public async send(command: AccessTokenRequestCommand): Promise<AccessTokenResponse>;
 
+  /**
+   * Refresh access token by refresh token
+   */
   public async send(command: RefreshTokenRequestCommand): Promise<RefreshTokenResponse>;
 
   public async send(command: AuthRequestCommands): Promise<AuthResponses> {

--- a/packages/test-utils/src/test-project/output/auth/AuthHono.ts
+++ b/packages/test-utils/src/test-project/output/auth/AuthHono.ts
@@ -24,8 +24,14 @@ import type { RefreshTokenResponse } from "./RefreshTokenResponse.js";
 import { RefreshTokenResponseValidator } from "./RefreshTokenResponseValidator.js";
 
 export type HonoAuthApiHandler = {
+  /**
+   * Get access token by email and password
+   */
   handleAccessTokenRequest: HonoRequestHandler<IAccessTokenRequest, AccessTokenResponse>;
 
+  /**
+   * Refresh access token by refresh token
+   */
   handleRefreshTokenRequest: HonoRequestHandler<IRefreshTokenRequest, RefreshTokenResponse>;
 };
 

--- a/packages/test-utils/src/test-project/output/auth/AuthHttpApiRoutes.ts
+++ b/packages/test-utils/src/test-project/output/auth/AuthHttpApiRoutes.ts
@@ -12,11 +12,17 @@ import { type AwsHttpApiGatewayRoute, AwsHttpApiGatewayRoutes } from "../lib/aws
 export class AuthHttpApiRoutes extends AwsHttpApiGatewayRoutes {
   private routes: AwsHttpApiGatewayRoute[] = [
     {
+      /**
+       * POST: Get access token by email and password
+       */
       path: "/auth/access-token",
       methods: [HttpMethod.POST],
     },
 
     {
+      /**
+       * POST: Refresh access token by refresh token
+       */
       path: "/auth/refresh-token",
       methods: [HttpMethod.POST],
     },

--- a/packages/test-utils/src/test-project/output/auth/AuthRouter.ts
+++ b/packages/test-utils/src/test-project/output/auth/AuthRouter.ts
@@ -25,8 +25,14 @@ import { RefreshTokenResponseValidator } from "./RefreshTokenResponseValidator.j
 
 export type ServerAuthApiHandler<TState extends Record<string, unknown> = Record<string, unknown>> =
   {
+    /**
+     * Get access token by email and password
+     */
     handleAccessTokenRequest: RequestHandler<IAccessTokenRequest, AccessTokenResponse, TState>;
 
+    /**
+     * Refresh access token by refresh token
+     */
     handleRefreshTokenRequest: RequestHandler<IRefreshTokenRequest, RefreshTokenResponse, TState>;
   };
 

--- a/packages/test-utils/src/test-project/output/auth/RefreshTokenRequest.ts
+++ b/packages/test-utils/src/test-project/output/auth/RefreshTokenRequest.ts
@@ -19,6 +19,9 @@ export type IRefreshTokenRequestBody = {
   refreshToken: string;
 };
 
+/**
+ * Refresh access token by refresh token
+ */
 export type IRefreshTokenRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/auth/RefreshTokenRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/auth/RefreshTokenRequestCommand.ts
@@ -26,6 +26,23 @@ import type { RefreshTokenResponse } from "./RefreshTokenResponse.js";
 const definition = getOperationDefinition(spec, "auth", "RefreshToken");
 const responseValidator = new RefreshTokenResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type RefreshTokenRequestCommandInput = Omit<
+  IRefreshTokenRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header?: Omit<IRefreshTokenRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IRefreshTokenRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Refresh access token by refresh token
+ */
 export class RefreshTokenRequestCommand extends RequestCommand implements IRefreshTokenRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -36,10 +53,10 @@ export class RefreshTokenRequestCommand extends RequestCommand implements IRefre
   declare public readonly query: undefined;
   public override readonly body: IRefreshTokenRequestBody;
 
-  public constructor(input: Omit<IRefreshTokenRequest, "method" | "path">) {
+  public constructor(input: RefreshTokenRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.body = input.body;
   }

--- a/packages/test-utils/src/test-project/output/file/DownloadFileContentRequest.ts
+++ b/packages/test-utils/src/test-project/output/file/DownloadFileContentRequest.ts
@@ -16,6 +16,9 @@ export type IDownloadFileContentRequestParam = {
   fileId: string;
 };
 
+/**
+ * Download file content
+ */
 export type IDownloadFileContentRequest = {
   path: string;
   method: HttpMethod.GET;

--- a/packages/test-utils/src/test-project/output/file/DownloadFileContentRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/file/DownloadFileContentRequestCommand.ts
@@ -26,6 +26,9 @@ import type { DownloadFileContentResponse } from "./DownloadFileContentResponse.
 const definition = getOperationDefinition(spec, "file", "DownloadFileContent");
 const responseValidator = new DownloadFileContentResponseValidator();
 
+/**
+ * Download file content
+ */
 export class DownloadFileContentRequestCommand
   extends RequestCommand
   implements IDownloadFileContentRequest

--- a/packages/test-utils/src/test-project/output/file/FileClient.ts
+++ b/packages/test-utils/src/test-project/output/file/FileClient.ts
@@ -32,12 +32,21 @@ export class FileClient extends ApiClient {
     super(props);
   }
 
+  /**
+   * Upload a file
+   */
   public async send(command: UploadFileRequestCommand): Promise<UploadFileResponse>;
 
+  /**
+   * Download file content
+   */
   public async send(
     command: DownloadFileContentRequestCommand,
   ): Promise<DownloadFileContentResponse>;
 
+  /**
+   * Get file metadata
+   */
   public async send(command: GetFileMetadataRequestCommand): Promise<GetFileMetadataResponse>;
 
   public async send(command: FileRequestCommands): Promise<FileResponses> {

--- a/packages/test-utils/src/test-project/output/file/FileHono.ts
+++ b/packages/test-utils/src/test-project/output/file/FileHono.ts
@@ -29,13 +29,22 @@ import type { DownloadFileContentResponse } from "./DownloadFileContentResponse.
 import { DownloadFileContentResponseValidator } from "./DownloadFileContentResponseValidator.js";
 
 export type HonoFileApiHandler = {
+  /**
+   * Upload a file
+   */
   handleUploadFileRequest: HonoRequestHandler<IUploadFileRequest, UploadFileResponse>;
 
+  /**
+   * Get file metadata
+   */
   handleGetFileMetadataRequest: HonoRequestHandler<
     IGetFileMetadataRequest,
     GetFileMetadataResponse
   >;
 
+  /**
+   * Download file content
+   */
   handleDownloadFileContentRequest: HonoRequestHandler<
     IDownloadFileContentRequest,
     DownloadFileContentResponse

--- a/packages/test-utils/src/test-project/output/file/FileHttpApiRoutes.ts
+++ b/packages/test-utils/src/test-project/output/file/FileHttpApiRoutes.ts
@@ -12,16 +12,25 @@ import { type AwsHttpApiGatewayRoute, AwsHttpApiGatewayRoutes } from "../lib/aws
 export class FileHttpApiRoutes extends AwsHttpApiGatewayRoutes {
   private routes: AwsHttpApiGatewayRoute[] = [
     {
+      /**
+       * POST: Upload a file
+       */
       path: "/files",
       methods: [HttpMethod.POST],
     },
 
     {
+      /**
+       * GET: Download file content
+       */
       path: "/files/{fileId}/content",
       methods: [HttpMethod.GET],
     },
 
     {
+      /**
+       * GET: Get file metadata
+       */
       path: "/files/{fileId}",
       methods: [HttpMethod.GET],
     },

--- a/packages/test-utils/src/test-project/output/file/FileRouter.ts
+++ b/packages/test-utils/src/test-project/output/file/FileRouter.ts
@@ -30,14 +30,23 @@ import { DownloadFileContentResponseValidator } from "./DownloadFileContentRespo
 
 export type ServerFileApiHandler<TState extends Record<string, unknown> = Record<string, unknown>> =
   {
+    /**
+     * Upload a file
+     */
     handleUploadFileRequest: RequestHandler<IUploadFileRequest, UploadFileResponse, TState>;
 
+    /**
+     * Get file metadata
+     */
     handleGetFileMetadataRequest: RequestHandler<
       IGetFileMetadataRequest,
       GetFileMetadataResponse,
       TState
     >;
 
+    /**
+     * Download file content
+     */
     handleDownloadFileContentRequest: RequestHandler<
       IDownloadFileContentRequest,
       DownloadFileContentResponse,

--- a/packages/test-utils/src/test-project/output/file/GetFileMetadataRequest.ts
+++ b/packages/test-utils/src/test-project/output/file/GetFileMetadataRequest.ts
@@ -19,6 +19,9 @@ export type IGetFileMetadataRequestParam = {
   fileId: string;
 };
 
+/**
+ * Get file metadata
+ */
 export type IGetFileMetadataRequest = {
   path: string;
   method: HttpMethod.GET;

--- a/packages/test-utils/src/test-project/output/file/GetFileMetadataRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/file/GetFileMetadataRequestCommand.ts
@@ -26,6 +26,21 @@ import type { GetFileMetadataResponse } from "./GetFileMetadataResponse.js";
 const definition = getOperationDefinition(spec, "file", "GetFileMetadata");
 const responseValidator = new GetFileMetadataResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type GetFileMetadataRequestCommandInput = Omit<
+  IGetFileMetadataRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IGetFileMetadataRequestHeader, "Accept"> &
+    Partial<Pick<IGetFileMetadataRequestHeader, "Accept">>;
+};
+
+/**
+ * Get file metadata
+ */
 export class GetFileMetadataRequestCommand
   extends RequestCommand
   implements IGetFileMetadataRequest
@@ -39,10 +54,10 @@ export class GetFileMetadataRequestCommand
   declare public readonly query: undefined;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IGetFileMetadataRequest, "method" | "path">) {
+  public constructor(input: GetFileMetadataRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
   }

--- a/packages/test-utils/src/test-project/output/file/UploadFileRequest.ts
+++ b/packages/test-utils/src/test-project/output/file/UploadFileRequest.ts
@@ -16,6 +16,9 @@ export type IUploadFileRequestHeader = {
 
 export type IUploadFileRequestBody = any;
 
+/**
+ * Upload a file
+ */
 export type IUploadFileRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/file/UploadFileRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/file/UploadFileRequestCommand.ts
@@ -26,6 +26,21 @@ import type { UploadFileResponse } from "./UploadFileResponse.js";
 const definition = getOperationDefinition(spec, "file", "UploadFile");
 const responseValidator = new UploadFileResponseValidator();
 
+const defaultHeader = {
+  "Content-Type": "application/octet-stream",
+} as const;
+
+export type UploadFileRequestCommandInput = Omit<
+  IUploadFileRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IUploadFileRequestHeader, "Content-Type"> &
+    Partial<Pick<IUploadFileRequestHeader, "Content-Type">>;
+};
+
+/**
+ * Upload a file
+ */
 export class UploadFileRequestCommand extends RequestCommand implements IUploadFileRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -36,10 +51,10 @@ export class UploadFileRequestCommand extends RequestCommand implements IUploadF
   declare public readonly query: undefined;
   public override readonly body: IUploadFileRequestBody;
 
-  public constructor(input: Omit<IUploadFileRequest, "method" | "path">) {
+  public constructor(input: UploadFileRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.body = input.body;
   }

--- a/packages/test-utils/src/test-project/output/lib/clients/ApiClient.ts
+++ b/packages/test-utils/src/test-project/output/lib/clients/ApiClient.ts
@@ -25,6 +25,11 @@ export type ApiClientProps = {
   readonly timeoutMs?: number;
 };
 
+type SerializedBody = {
+  readonly body: NonNullable<RequestInit["body"]> | undefined;
+  readonly isJsonSerialized: boolean;
+};
+
 const NETWORK_ERROR_MESSAGES: Readonly<Partial<Record<NetworkErrorCode, string>>> = {
   ECONNREFUSED: "Connection refused",
   ECONNRESET: "Connection reset by peer",
@@ -100,10 +105,16 @@ export abstract class ApiClient {
     const relativeUrl = this.createUrl(pathWithParam, query);
     const fullUrl = this.buildFullUrl(relativeUrl);
 
+    const serializedBody = this.serializeBody(body);
+    const headers = this.createRequestHeaders(
+      this.flattenHeaders(header),
+      serializedBody.isJsonSerialized,
+    );
+
     const response = await this.performFetch(method, fullUrl, {
       method,
-      headers: this.flattenHeaders(header),
-      body: this.serializeBody(body),
+      headers,
+      body: serializedBody.body,
       signal: this.timeoutMs !== undefined ? AbortSignal.timeout(this.timeoutMs) : undefined,
     });
 
@@ -264,11 +275,36 @@ export abstract class ApiClient {
     return flattened;
   }
 
-  private serializeBody(body: unknown): NonNullable<RequestInit["body"]> | undefined {
-    if (body === null || body === undefined) return undefined;
-    if (typeof body === "string") return body;
-    if (this.isNativeBody(body)) return body as NonNullable<RequestInit["body"]>;
-    return JSON.stringify(body);
+  private createRequestHeaders(
+    headers: Record<string, string> | undefined,
+    isJsonSerialized: boolean,
+  ): Record<string, string> | undefined {
+    if (!isJsonSerialized) return headers;
+
+    const requestHeaders = headers ? { ...headers } : {};
+    if (!this.hasContentTypeHeader(requestHeaders)) {
+      requestHeaders["Content-Type"] = "application/json";
+    }
+    return requestHeaders;
+  }
+
+  private hasContentTypeHeader(headers: Record<string, string>): boolean {
+    return Object.keys(headers).some((key) => key.toLowerCase() === "content-type");
+  }
+
+  private serializeBody(body: unknown): SerializedBody {
+    if (body === null || body === undefined) {
+      return { body: undefined, isJsonSerialized: false };
+    }
+    if (typeof body === "string") {
+      return { body, isJsonSerialized: false };
+    }
+    if (this.isNativeBody(body))
+      return {
+        body: body as NonNullable<RequestInit["body"]>,
+        isJsonSerialized: false,
+      };
+    return { body: JSON.stringify(body), isJsonSerialized: true };
   }
 
   private isNativeBody(body: unknown): boolean {

--- a/packages/test-utils/src/test-project/output/lib/server/TypeweaverApp.ts
+++ b/packages/test-utils/src/test-project/output/lib/server/TypeweaverApp.ts
@@ -230,9 +230,6 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
         const response = await this.executeHandler(routeCtx, match.route);
         return await this.validateResponse(match.route, normalizeHttpResponse(response), routeCtx);
       } catch (error) {
-        if (isTypedHttpResponse(error) && match.route.routerConfig.validateResponses) {
-          return await this.validateResponse(match.route, toHttpResponse(error), routeCtx);
-        }
         return this.handleError(error, routeCtx, match.route);
       }
     }
@@ -356,7 +353,9 @@ export class TypeweaverApp<TState extends Record<string, unknown> = {}> {
       );
       if (handler) {
         const response = await this.safelyExecuteErrorHandler(() => handler(error, ctx));
-        if (response) return response;
+        if (response) {
+          return await this.validateResponse(route, normalizeHttpResponse(response), ctx);
+        }
       }
     }
 

--- a/packages/test-utils/src/test-project/output/responses/AccessTokenSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/AccessTokenSuccessResponse.ts
@@ -20,6 +20,9 @@ export type IAccessTokenSuccessResponseBody = {
   refreshToken: string;
 };
 
+/**
+ * Access token created successfully
+ */
 export type IAccessTokenSuccessResponse = ITypedHttpResponse<
   "AccessTokenSuccess",
   HttpStatusCode.OK,
@@ -27,6 +30,9 @@ export type IAccessTokenSuccessResponse = ITypedHttpResponse<
   IAccessTokenSuccessResponseBody
 >;
 
+/**
+ * Access token created successfully
+ */
 export const createAccessTokenSuccessResponse = (input: {
   header: IAccessTokenSuccessResponseHeader;
   body: IAccessTokenSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/CreateSubTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/CreateSubTodoSuccessResponse.ts
@@ -31,6 +31,9 @@ export type ICreateSubTodoSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * SubTodo created successfully
+ */
 export type ICreateSubTodoSuccessResponse = ITypedHttpResponse<
   "CreateSubTodoSuccess",
   HttpStatusCode.CREATED,
@@ -38,6 +41,9 @@ export type ICreateSubTodoSuccessResponse = ITypedHttpResponse<
   ICreateSubTodoSuccessResponseBody
 >;
 
+/**
+ * SubTodo created successfully
+ */
 export const createCreateSubTodoSuccessResponse = (input: {
   header: ICreateSubTodoSuccessResponseHeader;
   body: ICreateSubTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/CreateTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/CreateTodoSuccessResponse.ts
@@ -31,6 +31,9 @@ export type ICreateTodoSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * Todo created successfully
+ */
 export type ICreateTodoSuccessResponse = ITypedHttpResponse<
   "CreateTodoSuccess",
   HttpStatusCode.CREATED,
@@ -38,6 +41,9 @@ export type ICreateTodoSuccessResponse = ITypedHttpResponse<
   ICreateTodoSuccessResponseBody
 >;
 
+/**
+ * Todo created successfully
+ */
 export const createCreateTodoSuccessResponse = (input: {
   header: ICreateTodoSuccessResponseHeader;
   body: ICreateTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/DeleteSubTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/DeleteSubTodoSuccessResponse.ts
@@ -19,6 +19,9 @@ export type IDeleteSubTodoSuccessResponseBody = {
   message: string;
 };
 
+/**
+ * SubTodo deleted successfully
+ */
 export type IDeleteSubTodoSuccessResponse = ITypedHttpResponse<
   "DeleteSubTodoSuccess",
   HttpStatusCode.OK,
@@ -26,6 +29,9 @@ export type IDeleteSubTodoSuccessResponse = ITypedHttpResponse<
   IDeleteSubTodoSuccessResponseBody
 >;
 
+/**
+ * SubTodo deleted successfully
+ */
 export const createDeleteSubTodoSuccessResponse = (input: {
   header: IDeleteSubTodoSuccessResponseHeader;
   body: IDeleteSubTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/DeleteTodoBodyOnlyResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/DeleteTodoBodyOnlyResponse.ts
@@ -13,6 +13,9 @@ export type IDeleteTodoBodyOnlyResponseBody = {
   message: string;
 };
 
+/**
+ * Success with body only
+ */
 export type IDeleteTodoBodyOnlyResponse = ITypedHttpResponse<
   "DeleteTodoBodyOnly",
   HttpStatusCode.OK,
@@ -20,6 +23,9 @@ export type IDeleteTodoBodyOnlyResponse = ITypedHttpResponse<
   IDeleteTodoBodyOnlyResponseBody
 >;
 
+/**
+ * Success with body only
+ */
 export const createDeleteTodoBodyOnlyResponse = (input: {
   body: IDeleteTodoBodyOnlyResponseBody;
 }): IDeleteTodoBodyOnlyResponse => ({

--- a/packages/test-utils/src/test-project/output/responses/DeleteTodoNoContentResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/DeleteTodoNoContentResponse.ts
@@ -9,6 +9,9 @@
 import { HttpStatusCode } from "@rexeus/typeweaver-core";
 import type { ITypedHttpResponse } from "@rexeus/typeweaver-core";
 
+/**
+ * No content response
+ */
 export type IDeleteTodoNoContentResponse = ITypedHttpResponse<
   "DeleteTodoNoContent",
   HttpStatusCode.NO_CONTENT,
@@ -16,6 +19,9 @@ export type IDeleteTodoNoContentResponse = ITypedHttpResponse<
   undefined
 >;
 
+/**
+ * No content response
+ */
 export const createDeleteTodoNoContentResponse = (): IDeleteTodoNoContentResponse => ({
   type: "DeleteTodoNoContent",
   statusCode: HttpStatusCode.NO_CONTENT,

--- a/packages/test-utils/src/test-project/output/responses/DeleteTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/DeleteTodoSuccessResponse.ts
@@ -15,6 +15,9 @@ export type IDeleteTodoSuccessResponseHeader = {
   "X-Multi-Value"?: string[] | undefined;
 };
 
+/**
+ * Todo deleted successfully
+ */
 export type IDeleteTodoSuccessResponse = ITypedHttpResponse<
   "DeleteTodoSuccess",
   HttpStatusCode.NO_CONTENT,
@@ -22,6 +25,9 @@ export type IDeleteTodoSuccessResponse = ITypedHttpResponse<
   undefined
 >;
 
+/**
+ * Todo deleted successfully
+ */
 export const createDeleteTodoSuccessResponse = (input: {
   header: IDeleteTodoSuccessResponseHeader;
 }): IDeleteTodoSuccessResponse => ({

--- a/packages/test-utils/src/test-project/output/responses/DownloadFileContentSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/DownloadFileContentSuccessResponse.ts
@@ -15,6 +15,9 @@ export type IDownloadFileContentSuccessResponseHeader = {
 
 export type IDownloadFileContentSuccessResponseBody = any;
 
+/**
+ * File content retrieved successfully
+ */
 export type IDownloadFileContentSuccessResponse = ITypedHttpResponse<
   "DownloadFileContentSuccess",
   HttpStatusCode.OK,
@@ -22,6 +25,9 @@ export type IDownloadFileContentSuccessResponse = ITypedHttpResponse<
   IDownloadFileContentSuccessResponseBody
 >;
 
+/**
+ * File content retrieved successfully
+ */
 export const createDownloadFileContentSuccessResponse = (input: {
   header: IDownloadFileContentSuccessResponseHeader;
   body: IDownloadFileContentSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/ForbiddenErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/ForbiddenErrorResponse.ts
@@ -20,6 +20,9 @@ export type IForbiddenErrorResponseBody = {
   code: "FORBIDDEN_ERROR";
 };
 
+/**
+ * Forbidden request
+ */
 export type IForbiddenErrorResponse = ITypedHttpResponse<
   "ForbiddenError",
   HttpStatusCode.FORBIDDEN,
@@ -27,6 +30,9 @@ export type IForbiddenErrorResponse = ITypedHttpResponse<
   IForbiddenErrorResponseBody
 >;
 
+/**
+ * Forbidden request
+ */
 export const createForbiddenErrorResponse = (input: {
   header: IForbiddenErrorResponseHeader;
   body: IForbiddenErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/GetFileMetadataSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/GetFileMetadataSuccessResponse.ts
@@ -23,6 +23,9 @@ export type IGetFileMetadataSuccessResponseBody = {
   createdAt: string;
 };
 
+/**
+ * File metadata retrieved successfully
+ */
 export type IGetFileMetadataSuccessResponse = ITypedHttpResponse<
   "GetFileMetadataSuccess",
   HttpStatusCode.OK,
@@ -30,6 +33,9 @@ export type IGetFileMetadataSuccessResponse = ITypedHttpResponse<
   IGetFileMetadataSuccessResponseBody
 >;
 
+/**
+ * File metadata retrieved successfully
+ */
 export const createGetFileMetadataSuccessResponse = (input: {
   header: IGetFileMetadataSuccessResponseHeader;
   body: IGetFileMetadataSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/GetTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/GetTodoSuccessResponse.ts
@@ -31,6 +31,9 @@ export type IGetTodoSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * Todo retrieved successfully
+ */
 export type IGetTodoSuccessResponse = ITypedHttpResponse<
   "GetTodoSuccess",
   HttpStatusCode.OK,
@@ -38,6 +41,9 @@ export type IGetTodoSuccessResponse = ITypedHttpResponse<
   IGetTodoSuccessResponseBody
 >;
 
+/**
+ * Todo retrieved successfully
+ */
 export const createGetTodoSuccessResponse = (input: {
   header: IGetTodoSuccessResponseHeader;
   body: IGetTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/HeadTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/HeadTodoSuccessResponse.ts
@@ -15,6 +15,9 @@ export type IHeadTodoSuccessResponseHeader = {
   "X-Multi-Value"?: string[] | undefined;
 };
 
+/**
+ * Todo exists
+ */
 export type IHeadTodoSuccessResponse = ITypedHttpResponse<
   "HeadTodoSuccess",
   HttpStatusCode.OK,
@@ -22,6 +25,9 @@ export type IHeadTodoSuccessResponse = ITypedHttpResponse<
   undefined
 >;
 
+/**
+ * Todo exists
+ */
 export const createHeadTodoSuccessResponse = (input: {
   header: IHeadTodoSuccessResponseHeader;
 }): IHeadTodoSuccessResponse => ({

--- a/packages/test-utils/src/test-project/output/responses/InternalServerErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/InternalServerErrorResponse.ts
@@ -20,6 +20,9 @@ export type IInternalServerErrorResponseBody = {
   code: "INTERNAL_SERVER_ERROR";
 };
 
+/**
+ * Internal server error occurred
+ */
 export type IInternalServerErrorResponse = ITypedHttpResponse<
   "InternalServerError",
   HttpStatusCode.INTERNAL_SERVER_ERROR,
@@ -27,6 +30,9 @@ export type IInternalServerErrorResponse = ITypedHttpResponse<
   IInternalServerErrorResponseBody
 >;
 
+/**
+ * Internal server error occurred
+ */
 export const createInternalServerErrorResponse = (input: {
   header: IInternalServerErrorResponseHeader;
   body: IInternalServerErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/ListSubTodosSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/ListSubTodosSuccessResponse.ts
@@ -34,6 +34,9 @@ export type IListSubTodosSuccessResponseBody = {
   nextToken?: string | undefined;
 };
 
+/**
+ * Subtodos retrieved successfully
+ */
 export type IListSubTodosSuccessResponse = ITypedHttpResponse<
   "ListSubTodosSuccess",
   HttpStatusCode.OK,
@@ -41,6 +44,9 @@ export type IListSubTodosSuccessResponse = ITypedHttpResponse<
   IListSubTodosSuccessResponseBody
 >;
 
+/**
+ * Subtodos retrieved successfully
+ */
 export const createListSubTodosSuccessResponse = (input: {
   header: IListSubTodosSuccessResponseHeader;
   body: IListSubTodosSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/ListTodosSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/ListTodosSuccessResponse.ts
@@ -34,6 +34,9 @@ export type IListTodosSuccessResponseBody = {
   nextToken?: string | undefined;
 };
 
+/**
+ * List todos successfully
+ */
 export type IListTodosSuccessResponse = ITypedHttpResponse<
   "ListTodosSuccess",
   HttpStatusCode.OK,
@@ -41,6 +44,9 @@ export type IListTodosSuccessResponse = ITypedHttpResponse<
   IListTodosSuccessResponseBody
 >;
 
+/**
+ * List todos successfully
+ */
 export const createListTodosSuccessResponse = (input: {
   header: IListTodosSuccessResponseHeader;
   body: IListTodosSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/OptionsTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/OptionsTodoSuccessResponse.ts
@@ -17,6 +17,9 @@ export type IOptionsTodoSuccessResponseHeader = {
   "Access-Control-Max-Age"?: string | undefined;
 };
 
+/**
+ * Allowed methods for todo resource
+ */
 export type IOptionsTodoSuccessResponse = ITypedHttpResponse<
   "OptionsTodoSuccess",
   HttpStatusCode.OK,
@@ -24,6 +27,9 @@ export type IOptionsTodoSuccessResponse = ITypedHttpResponse<
   undefined
 >;
 
+/**
+ * Allowed methods for todo resource
+ */
 export const createOptionsTodoSuccessResponse = (input: {
   header: IOptionsTodoSuccessResponseHeader;
 }): IOptionsTodoSuccessResponse => ({

--- a/packages/test-utils/src/test-project/output/responses/PutTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/PutTodoSuccessResponse.ts
@@ -31,6 +31,9 @@ export type IPutTodoSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * Todo replaced successfully
+ */
 export type IPutTodoSuccessResponse = ITypedHttpResponse<
   "PutTodoSuccess",
   HttpStatusCode.OK,
@@ -38,6 +41,9 @@ export type IPutTodoSuccessResponse = ITypedHttpResponse<
   IPutTodoSuccessResponseBody
 >;
 
+/**
+ * Todo replaced successfully
+ */
 export const createPutTodoSuccessResponse = (input: {
   header: IPutTodoSuccessResponseHeader;
   body: IPutTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/QuerySubTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/QuerySubTodoSuccessResponse.ts
@@ -34,6 +34,9 @@ export type IQuerySubTodoSuccessResponseBody = {
   nextToken?: string | undefined;
 };
 
+/**
+ * Subtodos query results
+ */
 export type IQuerySubTodoSuccessResponse = ITypedHttpResponse<
   "QuerySubTodoSuccess",
   HttpStatusCode.OK,
@@ -41,6 +44,9 @@ export type IQuerySubTodoSuccessResponse = ITypedHttpResponse<
   IQuerySubTodoSuccessResponseBody
 >;
 
+/**
+ * Subtodos query results
+ */
 export const createQuerySubTodoSuccessResponse = (input: {
   header: IQuerySubTodoSuccessResponseHeader;
   body: IQuerySubTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/QueryTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/QueryTodoSuccessResponse.ts
@@ -34,6 +34,9 @@ export type IQueryTodoSuccessResponseBody = {
   nextToken?: string | undefined;
 };
 
+/**
+ * Todos query results
+ */
 export type IQueryTodoSuccessResponse = ITypedHttpResponse<
   "QueryTodoSuccess",
   HttpStatusCode.OK,
@@ -41,6 +44,9 @@ export type IQueryTodoSuccessResponse = ITypedHttpResponse<
   IQueryTodoSuccessResponseBody
 >;
 
+/**
+ * Todos query results
+ */
 export const createQueryTodoSuccessResponse = (input: {
   header: IQueryTodoSuccessResponseHeader;
   body: IQueryTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/RefreshTokenSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/RefreshTokenSuccessResponse.ts
@@ -20,6 +20,9 @@ export type IRefreshTokenSuccessResponseBody = {
   refreshToken: string;
 };
 
+/**
+ * Refreshed token successfully
+ */
 export type IRefreshTokenSuccessResponse = ITypedHttpResponse<
   "RefreshTokenSuccess",
   HttpStatusCode.OK,
@@ -27,6 +30,9 @@ export type IRefreshTokenSuccessResponse = ITypedHttpResponse<
   IRefreshTokenSuccessResponseBody
 >;
 
+/**
+ * Refreshed token successfully
+ */
 export const createRefreshTokenSuccessResponse = (input: {
   header: IRefreshTokenSuccessResponseHeader;
   body: IRefreshTokenSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/RegisterAccountSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/RegisterAccountSuccessResponse.ts
@@ -24,6 +24,9 @@ export type IRegisterAccountSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * Account created successfully
+ */
 export type IRegisterAccountSuccessResponse = ITypedHttpResponse<
   "RegisterAccountSuccess",
   HttpStatusCode.CREATED,
@@ -31,6 +34,9 @@ export type IRegisterAccountSuccessResponse = ITypedHttpResponse<
   IRegisterAccountSuccessResponseBody
 >;
 
+/**
+ * Account created successfully
+ */
 export const createRegisterAccountSuccessResponse = (input: {
   header: IRegisterAccountSuccessResponseHeader;
   body: IRegisterAccountSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/SubTodoNotChangeableErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/SubTodoNotChangeableErrorResponse.ts
@@ -30,6 +30,9 @@ export type ISubTodoNotChangeableErrorResponseBody = {
   };
 };
 
+/**
+ * SubTodo in current status or because of parent todo status cannot be changed
+ */
 export type ISubTodoNotChangeableErrorResponse = ITypedHttpResponse<
   "SubTodoNotChangeableError",
   HttpStatusCode.CONFLICT,
@@ -37,6 +40,9 @@ export type ISubTodoNotChangeableErrorResponse = ITypedHttpResponse<
   ISubTodoNotChangeableErrorResponseBody
 >;
 
+/**
+ * SubTodo in current status or because of parent todo status cannot be changed
+ */
 export const createSubTodoNotChangeableErrorResponse = (input: {
   header: ISubTodoNotChangeableErrorResponseHeader;
   body: ISubTodoNotChangeableErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/SubTodoNotFoundErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/SubTodoNotFoundErrorResponse.ts
@@ -26,6 +26,9 @@ export type ISubTodoNotFoundErrorResponseBody = {
   };
 };
 
+/**
+ * SubTodo not found
+ */
 export type ISubTodoNotFoundErrorResponse = ITypedHttpResponse<
   "SubTodoNotFoundError",
   HttpStatusCode.NOT_FOUND,
@@ -33,6 +36,9 @@ export type ISubTodoNotFoundErrorResponse = ITypedHttpResponse<
   ISubTodoNotFoundErrorResponseBody
 >;
 
+/**
+ * SubTodo not found
+ */
 export const createSubTodoNotFoundErrorResponse = (input: {
   header: ISubTodoNotFoundErrorResponseHeader;
   body: ISubTodoNotFoundErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/SubTodoStatusTransitionInvalidErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/SubTodoStatusTransitionInvalidErrorResponse.ts
@@ -32,6 +32,9 @@ export type ISubTodoStatusTransitionInvalidErrorResponseBody = {
   };
 };
 
+/**
+ * SubTodo status transition is conflicting with its status or parent todo status
+ */
 export type ISubTodoStatusTransitionInvalidErrorResponse = ITypedHttpResponse<
   "SubTodoStatusTransitionInvalidError",
   HttpStatusCode.CONFLICT,
@@ -39,6 +42,9 @@ export type ISubTodoStatusTransitionInvalidErrorResponse = ITypedHttpResponse<
   ISubTodoStatusTransitionInvalidErrorResponseBody
 >;
 
+/**
+ * SubTodo status transition is conflicting with its status or parent todo status
+ */
 export const createSubTodoStatusTransitionInvalidErrorResponse = (input: {
   header: ISubTodoStatusTransitionInvalidErrorResponseHeader;
   body: ISubTodoStatusTransitionInvalidErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/TodoNotChangeableErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/TodoNotChangeableErrorResponse.ts
@@ -27,6 +27,9 @@ export type ITodoNotChangeableErrorResponseBody = {
   };
 };
 
+/**
+ * Todo in current status cannot be changed
+ */
 export type ITodoNotChangeableErrorResponse = ITypedHttpResponse<
   "TodoNotChangeableError",
   HttpStatusCode.CONFLICT,
@@ -34,6 +37,9 @@ export type ITodoNotChangeableErrorResponse = ITypedHttpResponse<
   ITodoNotChangeableErrorResponseBody
 >;
 
+/**
+ * Todo in current status cannot be changed
+ */
 export const createTodoNotChangeableErrorResponse = (input: {
   header: ITodoNotChangeableErrorResponseHeader;
   body: ITodoNotChangeableErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/TodoNotFoundErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/TodoNotFoundErrorResponse.ts
@@ -23,6 +23,9 @@ export type ITodoNotFoundErrorResponseBody = {
   };
 };
 
+/**
+ * Todo not found
+ */
 export type ITodoNotFoundErrorResponse = ITypedHttpResponse<
   "TodoNotFoundError",
   HttpStatusCode.NOT_FOUND,
@@ -30,6 +33,9 @@ export type ITodoNotFoundErrorResponse = ITypedHttpResponse<
   ITodoNotFoundErrorResponseBody
 >;
 
+/**
+ * Todo not found
+ */
 export const createTodoNotFoundErrorResponse = (input: {
   header: ITodoNotFoundErrorResponseHeader;
   body: ITodoNotFoundErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/TodoStatusTransitionInvalidErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/TodoStatusTransitionInvalidErrorResponse.ts
@@ -30,6 +30,9 @@ export type ITodoStatusTransitionInvalidErrorResponseBody = {
   };
 };
 
+/**
+ * Todo status transition is conflicting with current status
+ */
 export type ITodoStatusTransitionInvalidErrorResponse = ITypedHttpResponse<
   "TodoStatusTransitionInvalidError",
   HttpStatusCode.CONFLICT,
@@ -37,6 +40,9 @@ export type ITodoStatusTransitionInvalidErrorResponse = ITypedHttpResponse<
   ITodoStatusTransitionInvalidErrorResponseBody
 >;
 
+/**
+ * Todo status transition is conflicting with current status
+ */
 export const createTodoStatusTransitionInvalidErrorResponse = (input: {
   header: ITodoStatusTransitionInvalidErrorResponseHeader;
   body: ITodoStatusTransitionInvalidErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/TooManyRequestsErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/TooManyRequestsErrorResponse.ts
@@ -20,6 +20,9 @@ export type ITooManyRequestsErrorResponseBody = {
   code: "TOO_MANY_REQUESTS_ERROR";
 };
 
+/**
+ * Too many requests
+ */
 export type ITooManyRequestsErrorResponse = ITypedHttpResponse<
   "TooManyRequestsError",
   HttpStatusCode.TOO_MANY_REQUESTS,
@@ -27,6 +30,9 @@ export type ITooManyRequestsErrorResponse = ITypedHttpResponse<
   ITooManyRequestsErrorResponseBody
 >;
 
+/**
+ * Too many requests
+ */
 export const createTooManyRequestsErrorResponse = (input: {
   header: ITooManyRequestsErrorResponseHeader;
   body: ITooManyRequestsErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/UnauthorizedErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/UnauthorizedErrorResponse.ts
@@ -20,6 +20,9 @@ export type IUnauthorizedErrorResponseBody = {
   code: "UNAUTHORIZED_ERROR";
 };
 
+/**
+ * Unauthorized request
+ */
 export type IUnauthorizedErrorResponse = ITypedHttpResponse<
   "UnauthorizedError",
   HttpStatusCode.UNAUTHORIZED,
@@ -27,6 +30,9 @@ export type IUnauthorizedErrorResponse = ITypedHttpResponse<
   IUnauthorizedErrorResponseBody
 >;
 
+/**
+ * Unauthorized request
+ */
 export const createUnauthorizedErrorResponse = (input: {
   header: IUnauthorizedErrorResponseHeader;
   body: IUnauthorizedErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/UnsupportedMediaTypeErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/UnsupportedMediaTypeErrorResponse.ts
@@ -26,6 +26,9 @@ export type IUnsupportedMediaTypeErrorResponseBody = {
   };
 };
 
+/**
+ * Unsupported media type
+ */
 export type IUnsupportedMediaTypeErrorResponse = ITypedHttpResponse<
   "UnsupportedMediaTypeError",
   HttpStatusCode.UNSUPPORTED_MEDIA_TYPE,
@@ -33,6 +36,9 @@ export type IUnsupportedMediaTypeErrorResponse = ITypedHttpResponse<
   IUnsupportedMediaTypeErrorResponseBody
 >;
 
+/**
+ * Unsupported media type
+ */
 export const createUnsupportedMediaTypeErrorResponse = (input: {
   header: IUnsupportedMediaTypeErrorResponseHeader;
   body: IUnsupportedMediaTypeErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/UpdateSubTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/UpdateSubTodoSuccessResponse.ts
@@ -31,6 +31,9 @@ export type IUpdateSubTodoSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * SubTodo updated successfully
+ */
 export type IUpdateSubTodoSuccessResponse = ITypedHttpResponse<
   "UpdateSubTodoSuccess",
   HttpStatusCode.OK,
@@ -38,6 +41,9 @@ export type IUpdateSubTodoSuccessResponse = ITypedHttpResponse<
   IUpdateSubTodoSuccessResponseBody
 >;
 
+/**
+ * SubTodo updated successfully
+ */
 export const createUpdateSubTodoSuccessResponse = (input: {
   header: IUpdateSubTodoSuccessResponseHeader;
   body: IUpdateSubTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/UpdateTodoStatusSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/UpdateTodoStatusSuccessResponse.ts
@@ -31,6 +31,9 @@ export type IUpdateTodoStatusSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * Todo status updated successfully
+ */
 export type IUpdateTodoStatusSuccessResponse = ITypedHttpResponse<
   "UpdateTodoStatusSuccess",
   HttpStatusCode.OK,
@@ -38,6 +41,9 @@ export type IUpdateTodoStatusSuccessResponse = ITypedHttpResponse<
   IUpdateTodoStatusSuccessResponseBody
 >;
 
+/**
+ * Todo status updated successfully
+ */
 export const createUpdateTodoStatusSuccessResponse = (input: {
   header: IUpdateTodoStatusSuccessResponseHeader;
   body: IUpdateTodoStatusSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/UpdateTodoSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/UpdateTodoSuccessResponse.ts
@@ -31,6 +31,9 @@ export type IUpdateTodoSuccessResponseBody = {
   modifiedBy: string;
 };
 
+/**
+ * Todo updated successfully
+ */
 export type IUpdateTodoSuccessResponse = ITypedHttpResponse<
   "UpdateTodoSuccess",
   HttpStatusCode.OK,
@@ -38,6 +41,9 @@ export type IUpdateTodoSuccessResponse = ITypedHttpResponse<
   IUpdateTodoSuccessResponseBody
 >;
 
+/**
+ * Todo updated successfully
+ */
 export const createUpdateTodoSuccessResponse = (input: {
   header: IUpdateTodoSuccessResponseHeader;
   body: IUpdateTodoSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/UploadFileSuccessResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/UploadFileSuccessResponse.ts
@@ -23,6 +23,9 @@ export type IUploadFileSuccessResponseBody = {
   createdAt: string;
 };
 
+/**
+ * File uploaded successfully
+ */
 export type IUploadFileSuccessResponse = ITypedHttpResponse<
   "UploadFileSuccess",
   HttpStatusCode.CREATED,
@@ -30,6 +33,9 @@ export type IUploadFileSuccessResponse = ITypedHttpResponse<
   IUploadFileSuccessResponseBody
 >;
 
+/**
+ * File uploaded successfully
+ */
 export const createUploadFileSuccessResponse = (input: {
   header: IUploadFileSuccessResponseHeader;
   body: IUploadFileSuccessResponseBody;

--- a/packages/test-utils/src/test-project/output/responses/ValidationErrorResponse.ts
+++ b/packages/test-utils/src/test-project/output/responses/ValidationErrorResponse.ts
@@ -26,6 +26,9 @@ export type IValidationErrorResponseBody = {
   };
 };
 
+/**
+ * Validation error
+ */
 export type IValidationErrorResponse = ITypedHttpResponse<
   "ValidationError",
   HttpStatusCode.BAD_REQUEST,
@@ -33,6 +36,9 @@ export type IValidationErrorResponse = ITypedHttpResponse<
   IValidationErrorResponseBody
 >;
 
+/**
+ * Validation error
+ */
 export const createValidationErrorResponse = (input: {
   header: IValidationErrorResponseHeader;
   body: IValidationErrorResponseBody;

--- a/packages/test-utils/src/test-project/output/todo/CreateSubTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateSubTodoRequest.ts
@@ -28,6 +28,9 @@ export type ICreateSubTodoRequestBody = {
   priority?: ("LOW" | "MEDIUM" | "HIGH") | undefined;
 };
 
+/**
+ * Create new subtodo
+ */
 export type ICreateSubTodoRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/todo/CreateSubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateSubTodoRequestCommand.ts
@@ -27,6 +27,23 @@ import type { CreateSubTodoResponse } from "./CreateSubTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "CreateSubTodo");
 const responseValidator = new CreateSubTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type CreateSubTodoRequestCommandInput = Omit<
+  ICreateSubTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<ICreateSubTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<ICreateSubTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Create new subtodo
+ */
 export class CreateSubTodoRequestCommand extends RequestCommand implements ICreateSubTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -37,10 +54,10 @@ export class CreateSubTodoRequestCommand extends RequestCommand implements ICrea
   declare public readonly query: undefined;
   public override readonly body: ICreateSubTodoRequestBody;
 
-  public constructor(input: Omit<ICreateSubTodoRequest, "method" | "path">) {
+  public constructor(input: CreateSubTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/test-utils/src/test-project/output/todo/CreateTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateTodoRequest.ts
@@ -24,6 +24,9 @@ export type ICreateTodoRequestBody = {
   priority?: ("LOW" | "MEDIUM" | "HIGH") | undefined;
 };
 
+/**
+ * Create new todo
+ */
 export type ICreateTodoRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/todo/CreateTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/CreateTodoRequestCommand.ts
@@ -26,6 +26,23 @@ import type { CreateTodoResponse } from "./CreateTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "CreateTodo");
 const responseValidator = new CreateTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type CreateTodoRequestCommandInput = Omit<
+  ICreateTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<ICreateTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<ICreateTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Create new todo
+ */
 export class CreateTodoRequestCommand extends RequestCommand implements ICreateTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -36,10 +53,10 @@ export class CreateTodoRequestCommand extends RequestCommand implements ICreateT
   declare public readonly query: undefined;
   public override readonly body: ICreateTodoRequestBody;
 
-  public constructor(input: Omit<ICreateTodoRequest, "method" | "path">) {
+  public constructor(input: CreateTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.body = input.body;
   }

--- a/packages/test-utils/src/test-project/output/todo/DeleteSubTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteSubTodoRequest.ts
@@ -20,6 +20,9 @@ export type IDeleteSubTodoRequestParam = {
   subtodoId: string;
 };
 
+/**
+ * Delete subtodo
+ */
 export type IDeleteSubTodoRequest = {
   path: string;
   method: HttpMethod.DELETE;

--- a/packages/test-utils/src/test-project/output/todo/DeleteSubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteSubTodoRequestCommand.ts
@@ -26,6 +26,21 @@ import type { DeleteSubTodoResponse } from "./DeleteSubTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "DeleteSubTodo");
 const responseValidator = new DeleteSubTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type DeleteSubTodoRequestCommandInput = Omit<
+  IDeleteSubTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IDeleteSubTodoRequestHeader, "Accept"> &
+    Partial<Pick<IDeleteSubTodoRequestHeader, "Accept">>;
+};
+
+/**
+ * Delete subtodo
+ */
 export class DeleteSubTodoRequestCommand extends RequestCommand implements IDeleteSubTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.DELETE;
@@ -36,10 +51,10 @@ export class DeleteSubTodoRequestCommand extends RequestCommand implements IDele
   declare public readonly query: undefined;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IDeleteSubTodoRequest, "method" | "path">) {
+  public constructor(input: DeleteSubTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
   }

--- a/packages/test-utils/src/test-project/output/todo/DeleteTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteTodoRequest.ts
@@ -19,6 +19,9 @@ export type IDeleteTodoRequestParam = {
   todoId: string;
 };
 
+/**
+ * Delete todo
+ */
 export type IDeleteTodoRequest = {
   path: string;
   method: HttpMethod.DELETE;

--- a/packages/test-utils/src/test-project/output/todo/DeleteTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/DeleteTodoRequestCommand.ts
@@ -26,6 +26,21 @@ import type { DeleteTodoResponse } from "./DeleteTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "DeleteTodo");
 const responseValidator = new DeleteTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type DeleteTodoRequestCommandInput = Omit<
+  IDeleteTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IDeleteTodoRequestHeader, "Accept"> &
+    Partial<Pick<IDeleteTodoRequestHeader, "Accept">>;
+};
+
+/**
+ * Delete todo
+ */
 export class DeleteTodoRequestCommand extends RequestCommand implements IDeleteTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.DELETE;
@@ -36,10 +51,10 @@ export class DeleteTodoRequestCommand extends RequestCommand implements IDeleteT
   declare public readonly query: undefined;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IDeleteTodoRequest, "method" | "path">) {
+  public constructor(input: DeleteTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
   }

--- a/packages/test-utils/src/test-project/output/todo/GetTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/GetTodoRequest.ts
@@ -19,6 +19,9 @@ export type IGetTodoRequestParam = {
   todoId: string;
 };
 
+/**
+ * Get todo
+ */
 export type IGetTodoRequest = {
   path: string;
   method: HttpMethod.GET;

--- a/packages/test-utils/src/test-project/output/todo/GetTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/GetTodoRequestCommand.ts
@@ -26,6 +26,18 @@ import type { GetTodoResponse } from "./GetTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "GetTodo");
 const responseValidator = new GetTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type GetTodoRequestCommandInput = Omit<IGetTodoRequest, "method" | "path" | "header"> & {
+  readonly header: Omit<IGetTodoRequestHeader, "Accept"> &
+    Partial<Pick<IGetTodoRequestHeader, "Accept">>;
+};
+
+/**
+ * Get todo
+ */
 export class GetTodoRequestCommand extends RequestCommand implements IGetTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
@@ -36,10 +48,10 @@ export class GetTodoRequestCommand extends RequestCommand implements IGetTodoReq
   declare public readonly query: undefined;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IGetTodoRequest, "method" | "path">) {
+  public constructor(input: GetTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
   }

--- a/packages/test-utils/src/test-project/output/todo/HeadTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/HeadTodoRequest.ts
@@ -19,6 +19,9 @@ export type IHeadTodoRequestParam = {
   todoId: string;
 };
 
+/**
+ * Check if todo exists
+ */
 export type IHeadTodoRequest = {
   path: string;
   method: HttpMethod.HEAD;

--- a/packages/test-utils/src/test-project/output/todo/HeadTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/HeadTodoRequestCommand.ts
@@ -26,6 +26,18 @@ import type { HeadTodoResponse } from "./HeadTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "HeadTodo");
 const responseValidator = new HeadTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type HeadTodoRequestCommandInput = Omit<IHeadTodoRequest, "method" | "path" | "header"> & {
+  readonly header: Omit<IHeadTodoRequestHeader, "Accept"> &
+    Partial<Pick<IHeadTodoRequestHeader, "Accept">>;
+};
+
+/**
+ * Check if todo exists
+ */
 export class HeadTodoRequestCommand extends RequestCommand implements IHeadTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.HEAD;
@@ -36,10 +48,10 @@ export class HeadTodoRequestCommand extends RequestCommand implements IHeadTodoR
   declare public readonly query: undefined;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IHeadTodoRequest, "method" | "path">) {
+  public constructor(input: HeadTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
   }

--- a/packages/test-utils/src/test-project/output/todo/ListSubTodosRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListSubTodosRequest.ts
@@ -28,6 +28,9 @@ export type IListSubTodosRequestQuery =
     }
   | undefined;
 
+/**
+ * List subtodos for a specific todo
+ */
 export type IListSubTodosRequest = {
   path: string;
   method: HttpMethod.GET;

--- a/packages/test-utils/src/test-project/output/todo/ListSubTodosRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListSubTodosRequestCommand.ts
@@ -27,6 +27,21 @@ import type { ListSubTodosResponse } from "./ListSubTodosResponse.js";
 const definition = getOperationDefinition(spec, "todo", "ListSubTodos");
 const responseValidator = new ListSubTodosResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type ListSubTodosRequestCommandInput = Omit<
+  IListSubTodosRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IListSubTodosRequestHeader, "Accept"> &
+    Partial<Pick<IListSubTodosRequestHeader, "Accept">>;
+};
+
+/**
+ * List subtodos for a specific todo
+ */
 export class ListSubTodosRequestCommand extends RequestCommand implements IListSubTodosRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
@@ -37,10 +52,10 @@ export class ListSubTodosRequestCommand extends RequestCommand implements IListS
   public override readonly query: IListSubTodosRequestQuery;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IListSubTodosRequest, "method" | "path">) {
+  public constructor(input: ListSubTodosRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/test-utils/src/test-project/output/todo/ListTodosRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListTodosRequest.ts
@@ -28,6 +28,9 @@ export type IListTodosRequestQuery = {
   dateTo?: string | undefined;
 };
 
+/**
+ * List todos with filtering, pagination, and search
+ */
 export type IListTodosRequest = {
   path: string;
   method: HttpMethod.GET;

--- a/packages/test-utils/src/test-project/output/todo/ListTodosRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/ListTodosRequestCommand.ts
@@ -26,6 +26,18 @@ import type { ListTodosResponse } from "./ListTodosResponse.js";
 const definition = getOperationDefinition(spec, "todo", "ListTodos");
 const responseValidator = new ListTodosResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type ListTodosRequestCommandInput = Omit<IListTodosRequest, "method" | "path" | "header"> & {
+  readonly header: Omit<IListTodosRequestHeader, "Accept"> &
+    Partial<Pick<IListTodosRequestHeader, "Accept">>;
+};
+
+/**
+ * List todos with filtering, pagination, and search
+ */
 export class ListTodosRequestCommand extends RequestCommand implements IListTodosRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.GET;
@@ -36,10 +48,10 @@ export class ListTodosRequestCommand extends RequestCommand implements IListTodo
   public override readonly query: IListTodosRequestQuery;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IListTodosRequest, "method" | "path">) {
+  public constructor(input: ListTodosRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.query = input.query;
   }

--- a/packages/test-utils/src/test-project/output/todo/OptionsTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/OptionsTodoRequest.ts
@@ -21,6 +21,9 @@ export type IOptionsTodoRequestParam = {
   todoId: string;
 };
 
+/**
+ * Get allowed methods for todo resource
+ */
 export type IOptionsTodoRequest = {
   path: string;
   method: HttpMethod.OPTIONS;

--- a/packages/test-utils/src/test-project/output/todo/OptionsTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/OptionsTodoRequestCommand.ts
@@ -26,6 +26,21 @@ import type { OptionsTodoResponse } from "./OptionsTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "optionsTodo");
 const responseValidator = new OptionsTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+} as const;
+
+export type OptionsTodoRequestCommandInput = Omit<
+  IOptionsTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IOptionsTodoRequestHeader, "Accept"> &
+    Partial<Pick<IOptionsTodoRequestHeader, "Accept">>;
+};
+
+/**
+ * Get allowed methods for todo resource
+ */
 export class OptionsTodoRequestCommand extends RequestCommand implements IOptionsTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.OPTIONS;
@@ -36,10 +51,10 @@ export class OptionsTodoRequestCommand extends RequestCommand implements IOption
   declare public readonly query: undefined;
   declare public readonly body: undefined;
 
-  public constructor(input: Omit<IOptionsTodoRequest, "method" | "path">) {
+  public constructor(input: OptionsTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
   }

--- a/packages/test-utils/src/test-project/output/todo/PutTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/PutTodoRequest.ts
@@ -31,6 +31,9 @@ export type IPutTodoRequestBody = {
   priority?: ("LOW" | "MEDIUM" | "HIGH") | undefined;
 };
 
+/**
+ * Replace todo completely
+ */
 export type IPutTodoRequest = {
   path: string;
   method: HttpMethod.PUT;

--- a/packages/test-utils/src/test-project/output/todo/PutTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/PutTodoRequestCommand.ts
@@ -27,6 +27,20 @@ import type { PutTodoResponse } from "./PutTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "PutTodo");
 const responseValidator = new PutTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type PutTodoRequestCommandInput = Omit<IPutTodoRequest, "method" | "path" | "header"> & {
+  readonly header: Omit<IPutTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IPutTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Replace todo completely
+ */
 export class PutTodoRequestCommand extends RequestCommand implements IPutTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PUT;
@@ -37,10 +51,10 @@ export class PutTodoRequestCommand extends RequestCommand implements IPutTodoReq
   declare public readonly query: undefined;
   public override readonly body: IPutTodoRequestBody;
 
-  public constructor(input: Omit<IPutTodoRequest, "method" | "path">) {
+  public constructor(input: PutTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/test-utils/src/test-project/output/todo/QuerySubTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/QuerySubTodoRequest.ts
@@ -41,6 +41,9 @@ export type IQuerySubTodoRequestBody = {
   tags?: string[] | undefined;
 };
 
+/**
+ * Query subtodos for a specific todo
+ */
 export type IQuerySubTodoRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/todo/QuerySubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/QuerySubTodoRequestCommand.ts
@@ -28,6 +28,23 @@ import type { QuerySubTodoResponse } from "./QuerySubTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "QuerySubTodo");
 const responseValidator = new QuerySubTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type QuerySubTodoRequestCommandInput = Omit<
+  IQuerySubTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IQuerySubTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IQuerySubTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Query subtodos for a specific todo
+ */
 export class QuerySubTodoRequestCommand extends RequestCommand implements IQuerySubTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -38,10 +55,10 @@ export class QuerySubTodoRequestCommand extends RequestCommand implements IQuery
   public override readonly query: IQuerySubTodoRequestQuery;
   public override readonly body: IQuerySubTodoRequestBody;
 
-  public constructor(input: Omit<IQuerySubTodoRequest, "method" | "path">) {
+  public constructor(input: QuerySubTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/test-utils/src/test-project/output/todo/QueryTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/QueryTodoRequest.ts
@@ -38,6 +38,9 @@ export type IQueryTodoRequestBody = {
   hasParent?: boolean | undefined;
 };
 
+/**
+ * Query todos with advanced search criteria
+ */
 export type IQueryTodoRequest = {
   path: string;
   method: HttpMethod.POST;

--- a/packages/test-utils/src/test-project/output/todo/QueryTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/QueryTodoRequestCommand.ts
@@ -27,6 +27,20 @@ import type { QueryTodoResponse } from "./QueryTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "QueryTodo");
 const responseValidator = new QueryTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type QueryTodoRequestCommandInput = Omit<IQueryTodoRequest, "method" | "path" | "header"> & {
+  readonly header: Omit<IQueryTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IQueryTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Query todos with advanced search criteria
+ */
 export class QueryTodoRequestCommand extends RequestCommand implements IQueryTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.POST;
@@ -37,10 +51,10 @@ export class QueryTodoRequestCommand extends RequestCommand implements IQueryTod
   public override readonly query: IQueryTodoRequestQuery;
   public override readonly body: IQueryTodoRequestBody;
 
-  public constructor(input: Omit<IQueryTodoRequest, "method" | "path">) {
+  public constructor(input: QueryTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.query = input.query;
 

--- a/packages/test-utils/src/test-project/output/todo/TodoClient.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoClient.ts
@@ -92,34 +92,79 @@ export class TodoClient extends ApiClient {
     super(props);
   }
 
+  /**
+   * Create new subtodo
+   */
   public async send(command: CreateSubTodoRequestCommand): Promise<CreateSubTodoResponse>;
 
+  /**
+   * Create new todo
+   */
   public async send(command: CreateTodoRequestCommand): Promise<CreateTodoResponse>;
 
+  /**
+   * Delete subtodo
+   */
   public async send(command: DeleteSubTodoRequestCommand): Promise<DeleteSubTodoResponse>;
 
+  /**
+   * Delete todo
+   */
   public async send(command: DeleteTodoRequestCommand): Promise<DeleteTodoResponse>;
 
+  /**
+   * Get todo
+   */
   public async send(command: GetTodoRequestCommand): Promise<GetTodoResponse>;
 
+  /**
+   * Check if todo exists
+   */
   public async send(command: HeadTodoRequestCommand): Promise<HeadTodoResponse>;
 
+  /**
+   * List subtodos for a specific todo
+   */
   public async send(command: ListSubTodosRequestCommand): Promise<ListSubTodosResponse>;
 
+  /**
+   * List todos with filtering, pagination, and search
+   */
   public async send(command: ListTodosRequestCommand): Promise<ListTodosResponse>;
 
+  /**
+   * Get allowed methods for todo resource
+   */
   public async send(command: OptionsTodoRequestCommand): Promise<OptionsTodoResponse>;
 
+  /**
+   * Replace todo completely
+   */
   public async send(command: PutTodoRequestCommand): Promise<PutTodoResponse>;
 
+  /**
+   * Query subtodos for a specific todo
+   */
   public async send(command: QuerySubTodoRequestCommand): Promise<QuerySubTodoResponse>;
 
+  /**
+   * Query todos with advanced search criteria
+   */
   public async send(command: QueryTodoRequestCommand): Promise<QueryTodoResponse>;
 
+  /**
+   * Update subtodo
+   */
   public async send(command: UpdateSubTodoRequestCommand): Promise<UpdateSubTodoResponse>;
 
+  /**
+   * Update todo
+   */
   public async send(command: UpdateTodoRequestCommand): Promise<UpdateTodoResponse>;
 
+  /**
+   * Update todo status
+   */
   public async send(command: UpdateTodoStatusRequestCommand): Promise<UpdateTodoStatusResponse>;
 
   public async send(command: TodoRequestCommands): Promise<TodoResponses> {

--- a/packages/test-utils/src/test-project/output/todo/TodoHono.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoHono.ts
@@ -84,35 +84,77 @@ import type { DeleteSubTodoResponse } from "./DeleteSubTodoResponse.js";
 import { DeleteSubTodoResponseValidator } from "./DeleteSubTodoResponseValidator.js";
 
 export type HonoTodoApiHandler = {
+  /**
+   * List todos with filtering, pagination, and search
+   */
   handleListTodosRequest: HonoRequestHandler<IListTodosRequest, ListTodosResponse>;
 
+  /**
+   * Create new todo
+   */
   handleCreateTodoRequest: HonoRequestHandler<ICreateTodoRequest, CreateTodoResponse>;
 
+  /**
+   * Query todos with advanced search criteria
+   */
   handleQueryTodoRequest: HonoRequestHandler<IQueryTodoRequest, QueryTodoResponse>;
 
+  /**
+   * Get todo
+   */
   handleGetTodoRequest: HonoRequestHandler<IGetTodoRequest, GetTodoResponse>;
 
+  /**
+   * Replace todo completely
+   */
   handlePutTodoRequest: HonoRequestHandler<IPutTodoRequest, PutTodoResponse>;
 
+  /**
+   * Update todo
+   */
   handleUpdateTodoRequest: HonoRequestHandler<IUpdateTodoRequest, UpdateTodoResponse>;
 
+  /**
+   * Delete todo
+   */
   handleDeleteTodoRequest: HonoRequestHandler<IDeleteTodoRequest, DeleteTodoResponse>;
 
+  /**
+   * Get allowed methods for todo resource
+   */
   handleOptionsTodoRequest: HonoRequestHandler<IOptionsTodoRequest, OptionsTodoResponse>;
 
+  /**
+   * Update todo status
+   */
   handleUpdateTodoStatusRequest: HonoRequestHandler<
     IUpdateTodoStatusRequest,
     UpdateTodoStatusResponse
   >;
 
+  /**
+   * List subtodos for a specific todo
+   */
   handleListSubTodosRequest: HonoRequestHandler<IListSubTodosRequest, ListSubTodosResponse>;
 
+  /**
+   * Create new subtodo
+   */
   handleCreateSubTodoRequest: HonoRequestHandler<ICreateSubTodoRequest, CreateSubTodoResponse>;
 
+  /**
+   * Query subtodos for a specific todo
+   */
   handleQuerySubTodoRequest: HonoRequestHandler<IQuerySubTodoRequest, QuerySubTodoResponse>;
 
+  /**
+   * Update subtodo
+   */
   handleUpdateSubTodoRequest: HonoRequestHandler<IUpdateSubTodoRequest, UpdateSubTodoResponse>;
 
+  /**
+   * Delete subtodo
+   */
   handleDeleteSubTodoRequest: HonoRequestHandler<IDeleteSubTodoRequest, DeleteSubTodoResponse>;
 };
 

--- a/packages/test-utils/src/test-project/output/todo/TodoHttpApiRoutes.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoHttpApiRoutes.ts
@@ -12,21 +12,41 @@ import { type AwsHttpApiGatewayRoute, AwsHttpApiGatewayRoutes } from "../lib/aws
 export class TodoHttpApiRoutes extends AwsHttpApiGatewayRoutes {
   private routes: AwsHttpApiGatewayRoute[] = [
     {
+      /**
+       * POST: Create new subtodo
+       * GET: List subtodos for a specific todo
+       */
       path: "/todos/{todoId}/subtodos",
       methods: [HttpMethod.POST, HttpMethod.GET],
     },
 
     {
+      /**
+       * POST: Create new todo
+       * GET: List todos with filtering, pagination, and search
+       */
       path: "/todos",
       methods: [HttpMethod.POST, HttpMethod.GET],
     },
 
     {
+      /**
+       * DELETE: Delete subtodo
+       * PUT: Update subtodo
+       */
       path: "/todos/{todoId}/subtodos/{subtodoId}",
       methods: [HttpMethod.DELETE, HttpMethod.PUT],
     },
 
     {
+      /**
+       * DELETE: Delete todo
+       * GET: Get todo
+       * HEAD: Check if todo exists
+       * OPTIONS: Get allowed methods for todo resource
+       * PUT: Replace todo completely
+       * PATCH: Update todo
+       */
       path: "/todos/{todoId}",
       methods: [
         HttpMethod.DELETE,
@@ -39,16 +59,25 @@ export class TodoHttpApiRoutes extends AwsHttpApiGatewayRoutes {
     },
 
     {
+      /**
+       * POST: Query subtodos for a specific todo
+       */
       path: "/todos/{todoId}/subtodos/query",
       methods: [HttpMethod.POST],
     },
 
     {
+      /**
+       * POST: Query todos with advanced search criteria
+       */
       path: "/todos/query",
       methods: [HttpMethod.POST],
     },
 
     {
+      /**
+       * PUT: Update todo status
+       */
       path: "/todos/{todoId}/status",
       methods: [HttpMethod.PUT],
     },

--- a/packages/test-utils/src/test-project/output/todo/TodoRouter.ts
+++ b/packages/test-utils/src/test-project/output/todo/TodoRouter.ts
@@ -85,44 +85,86 @@ import { DeleteSubTodoResponseValidator } from "./DeleteSubTodoResponseValidator
 
 export type ServerTodoApiHandler<TState extends Record<string, unknown> = Record<string, unknown>> =
   {
+    /**
+     * List todos with filtering, pagination, and search
+     */
     handleListTodosRequest: RequestHandler<IListTodosRequest, ListTodosResponse, TState>;
 
+    /**
+     * Create new todo
+     */
     handleCreateTodoRequest: RequestHandler<ICreateTodoRequest, CreateTodoResponse, TState>;
 
+    /**
+     * Query todos with advanced search criteria
+     */
     handleQueryTodoRequest: RequestHandler<IQueryTodoRequest, QueryTodoResponse, TState>;
 
+    /**
+     * Get todo
+     */
     handleGetTodoRequest: RequestHandler<IGetTodoRequest, GetTodoResponse, TState>;
 
+    /**
+     * Replace todo completely
+     */
     handlePutTodoRequest: RequestHandler<IPutTodoRequest, PutTodoResponse, TState>;
 
+    /**
+     * Update todo
+     */
     handleUpdateTodoRequest: RequestHandler<IUpdateTodoRequest, UpdateTodoResponse, TState>;
 
+    /**
+     * Delete todo
+     */
     handleDeleteTodoRequest: RequestHandler<IDeleteTodoRequest, DeleteTodoResponse, TState>;
 
+    /**
+     * Get allowed methods for todo resource
+     */
     handleOptionsTodoRequest: RequestHandler<IOptionsTodoRequest, OptionsTodoResponse, TState>;
 
+    /**
+     * Update todo status
+     */
     handleUpdateTodoStatusRequest: RequestHandler<
       IUpdateTodoStatusRequest,
       UpdateTodoStatusResponse,
       TState
     >;
 
+    /**
+     * List subtodos for a specific todo
+     */
     handleListSubTodosRequest: RequestHandler<IListSubTodosRequest, ListSubTodosResponse, TState>;
 
+    /**
+     * Create new subtodo
+     */
     handleCreateSubTodoRequest: RequestHandler<
       ICreateSubTodoRequest,
       CreateSubTodoResponse,
       TState
     >;
 
+    /**
+     * Query subtodos for a specific todo
+     */
     handleQuerySubTodoRequest: RequestHandler<IQuerySubTodoRequest, QuerySubTodoResponse, TState>;
 
+    /**
+     * Update subtodo
+     */
     handleUpdateSubTodoRequest: RequestHandler<
       IUpdateSubTodoRequest,
       UpdateSubTodoResponse,
       TState
     >;
 
+    /**
+     * Delete subtodo
+     */
     handleDeleteSubTodoRequest: RequestHandler<
       IDeleteSubTodoRequest,
       DeleteSubTodoResponse,

--- a/packages/test-utils/src/test-project/output/todo/UpdateSubTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateSubTodoRequest.ts
@@ -30,6 +30,9 @@ export type IUpdateSubTodoRequestBody = {
   priority?: (("LOW" | "MEDIUM" | "HIGH") | undefined) | undefined;
 };
 
+/**
+ * Update subtodo
+ */
 export type IUpdateSubTodoRequest = {
   path: string;
   method: HttpMethod.PUT;

--- a/packages/test-utils/src/test-project/output/todo/UpdateSubTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateSubTodoRequestCommand.ts
@@ -27,6 +27,23 @@ import type { UpdateSubTodoResponse } from "./UpdateSubTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "UpdateSubTodo");
 const responseValidator = new UpdateSubTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type UpdateSubTodoRequestCommandInput = Omit<
+  IUpdateSubTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IUpdateSubTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IUpdateSubTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Update subtodo
+ */
 export class UpdateSubTodoRequestCommand extends RequestCommand implements IUpdateSubTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PUT;
@@ -37,10 +54,10 @@ export class UpdateSubTodoRequestCommand extends RequestCommand implements IUpda
   declare public readonly query: undefined;
   public override readonly body: IUpdateSubTodoRequestBody;
 
-  public constructor(input: Omit<IUpdateSubTodoRequest, "method" | "path">) {
+  public constructor(input: UpdateSubTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoRequest.ts
@@ -28,6 +28,9 @@ export type IUpdateTodoRequestBody = {
   priority?: (("LOW" | "MEDIUM" | "HIGH") | undefined) | undefined;
 };
 
+/**
+ * Update todo
+ */
 export type IUpdateTodoRequest = {
   path: string;
   method: HttpMethod.PATCH;

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoRequestCommand.ts
@@ -27,6 +27,23 @@ import type { UpdateTodoResponse } from "./UpdateTodoResponse.js";
 const definition = getOperationDefinition(spec, "todo", "UpdateTodo");
 const responseValidator = new UpdateTodoResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type UpdateTodoRequestCommandInput = Omit<
+  IUpdateTodoRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IUpdateTodoRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IUpdateTodoRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Update todo
+ */
 export class UpdateTodoRequestCommand extends RequestCommand implements IUpdateTodoRequest {
   public override readonly operationId = definition.operationId;
   public override readonly method = definition.method as HttpMethod.PATCH;
@@ -37,10 +54,10 @@ export class UpdateTodoRequestCommand extends RequestCommand implements IUpdateT
   declare public readonly query: undefined;
   public override readonly body: IUpdateTodoRequestBody;
 
-  public constructor(input: Omit<IUpdateTodoRequest, "method" | "path">) {
+  public constructor(input: UpdateTodoRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusRequest.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusRequest.ts
@@ -24,6 +24,9 @@ export type IUpdateTodoStatusRequestBody = {
   value: "TODO" | "IN_PROGRESS" | "DONE" | "ARCHIVED";
 };
 
+/**
+ * Update todo status
+ */
 export type IUpdateTodoStatusRequest = {
   path: string;
   method: HttpMethod.PUT;

--- a/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusRequestCommand.ts
+++ b/packages/test-utils/src/test-project/output/todo/UpdateTodoStatusRequestCommand.ts
@@ -27,6 +27,23 @@ import type { UpdateTodoStatusResponse } from "./UpdateTodoStatusResponse.js";
 const definition = getOperationDefinition(spec, "todo", "UpdateTodoStatus");
 const responseValidator = new UpdateTodoStatusResponseValidator();
 
+const defaultHeader = {
+  Accept: "application/json",
+
+  "Content-Type": "application/json",
+} as const;
+
+export type UpdateTodoStatusRequestCommandInput = Omit<
+  IUpdateTodoStatusRequest,
+  "method" | "path" | "header"
+> & {
+  readonly header: Omit<IUpdateTodoStatusRequestHeader, "Accept" | "Content-Type"> &
+    Partial<Pick<IUpdateTodoStatusRequestHeader, "Accept" | "Content-Type">>;
+};
+
+/**
+ * Update todo status
+ */
 export class UpdateTodoStatusRequestCommand
   extends RequestCommand
   implements IUpdateTodoStatusRequest
@@ -40,10 +57,10 @@ export class UpdateTodoStatusRequestCommand
   declare public readonly query: undefined;
   public override readonly body: IUpdateTodoStatusRequestBody;
 
-  public constructor(input: Omit<IUpdateTodoStatusRequest, "method" | "path">) {
+  public constructor(input: UpdateTodoStatusRequestCommandInput) {
     super();
 
-    this.header = input.header;
+    this.header = { ...input.header, ...defaultHeader };
 
     this.param = input.param;
 

--- a/packages/types/__test__/unit/responseGenerator.test.ts
+++ b/packages/types/__test__/unit/responseGenerator.test.ts
@@ -762,4 +762,43 @@ describe("ResponseGenerator", () => {
     expect(source).toMatch(/ITypedHttpResponse<\s*"createdTodo"/);
     expect(source).toContain('type: "createdTodo"');
   });
+
+  test("renders response descriptions as JSDoc above response aliases and factories", () => {
+    const source = renderCanonicalResponseSource(
+      aCanonicalResponse({
+        name: "documentedResponse",
+        description: "Documented response",
+      })
+    );
+
+    expect(source).toContain(
+      "/**\n * Documented response\n */\nexport type IDocumentedResponseResponse"
+    );
+    expect(source).toContain(
+      "/**\n * Documented response\n */\nexport const createDocumentedResponseResponse"
+    );
+  });
+
+  test("preserves multiline response descriptions in generated JSDoc", () => {
+    const source = renderCanonicalResponseSource(
+      aCanonicalResponse({
+        name: "multilineResponse",
+        description: "First line\n\nSecond line",
+      })
+    );
+
+    expect(source).toContain("/**\n * First line\n * \n * Second line\n */");
+  });
+
+  test("sanitizes response descriptions before emitting generated JSDoc", () => {
+    const source = renderCanonicalResponseSource(
+      aCanonicalResponse({
+        name: "sanitizedResponse",
+        description: "Do not close */ comments",
+      })
+    );
+
+    expect(source).toContain("Do not close *\\/ comments");
+    expect(source).not.toContain("Do not close */ comments");
+  });
 });

--- a/packages/types/src/requestGenerator.ts
+++ b/packages/types/src/requestGenerator.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createJSDocComment } from "@rexeus/typeweaver-gen";
 import type {
   GeneratorContext,
   NormalizedOperation,
@@ -35,6 +36,7 @@ function writeRequestType(
   const content = context.renderTemplate(templateFilePath, {
     pascalCaseOperationId: pascalCase(operationId),
     method,
+    requestJsDoc: createJSDocComment(operation.summary),
     headerTsType: header ? print(fromZod(header)) : undefined,
     queryTsType: query ? print(fromZod(query)) : undefined,
     paramTsType: param ? print(fromZod(param)) : undefined,

--- a/packages/types/src/responseGenerator.ts
+++ b/packages/types/src/responseGenerator.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { HttpStatusCode } from "@rexeus/typeweaver-core";
+import { createJSDocComment } from "@rexeus/typeweaver-gen";
 import type {
   GeneratorContext,
   NormalizedOperation,
@@ -44,6 +45,7 @@ type OwnResponseTemplateData = {
   readonly hasHeader: boolean;
   readonly hasBody: boolean;
   readonly factory: string;
+  readonly jsDoc?: string;
 };
 
 type ResponseFactoryTemplateData = {
@@ -52,6 +54,7 @@ type ResponseFactoryTemplateData = {
   readonly statusCodeKey: string;
   readonly hasHeader: boolean;
   readonly hasBody: boolean;
+  readonly jsDoc?: string;
 };
 
 type RenderResponseFactoryTemplateData = ResponseFactoryTemplateData & {
@@ -164,6 +167,7 @@ function createOwnResponseTemplateData(
     statusCodeKey: HttpStatusCode[response.statusCode],
     hasHeader,
     hasBody,
+    jsDoc: createJSDocComment(response.description),
   };
 
   return {
@@ -197,6 +201,7 @@ function writeCanonicalResponseType(
     statusCodeKey: HttpStatusCode[response.statusCode],
     hasHeader: response.header !== undefined,
     hasBody: response.body !== undefined,
+    jsDoc: createJSDocComment(response.description),
   };
 
   const content = context.renderTemplate(templateFile, {

--- a/packages/types/src/templates/Request.ejs
+++ b/packages/types/src/templates/Request.ejs
@@ -24,7 +24,8 @@ export type I<%= pascalCaseOperationId %>RequestQuery = <%- queryTsType %>
 export type I<%= pascalCaseOperationId %>RequestBody = <%- bodyTsType %>
 <% } %>
 
-export type I<%= pascalCaseOperationId %>Request = {
+<% if (requestJsDoc) { %><%- requestJsDoc %>
+<% } %>export type I<%= pascalCaseOperationId %>Request = {
     path: string;
     method: HttpMethod.<%= method %>;
     <%= headerTsType ? `header: I${pascalCaseOperationId}RequestHeader;` : "" %>
@@ -32,4 +33,3 @@ export type I<%= pascalCaseOperationId %>Request = {
     <%= queryTsType ? `query: I${pascalCaseOperationId}RequestQuery;` : "" %>
     <%= bodyTsType ? `body: I${pascalCaseOperationId}RequestBody;` : "" %>
 };
-

--- a/packages/types/src/templates/Response.ejs
+++ b/packages/types/src/templates/Response.ejs
@@ -26,7 +26,8 @@ import type { I<%= entityResponse.identifierName %>Response } from "<%= entityRe
         export type I<%= ownResponse.identifierName %>ResponseBody = <%- ownResponse.body %>;
     <% } %>
 
-    export type I<%= ownResponse.identifierName %>Response = ITypedHttpResponse<
+    <% if (ownResponse.jsDoc) { %><%- ownResponse.jsDoc.split('\n').map(line => `    ${line}`).join('\n') %>
+    <% } %>export type I<%= ownResponse.identifierName %>Response = ITypedHttpResponse<
             "<%= ownResponse.typeValue %>",
             HttpStatusCode.<%= ownResponse.statusCodeKey %>,
             <%= ownResponse.hasHeader ? `I${ownResponse.identifierName}ResponseHeader` : 'undefined' %>,

--- a/packages/types/src/templates/ResponseFactory.ejs
+++ b/packages/types/src/templates/ResponseFactory.ejs
@@ -1,4 +1,5 @@
-<%= indentation %>export const create<%= identifierName %>Response = <% if (hasHeader || hasBody) { %>(
+<% if (jsDoc) { %><%- jsDoc.split('\n').map(line => `${indentation}${line}`).join('\n') %>
+<% } %><%= indentation %>export const create<%= identifierName %>Response = <% if (hasHeader || hasBody) { %>(
 <%= indentation %>input: {
 <% if (hasHeader) { %><%= indentation %>  header: I<%= identifierName %>ResponseHeader;
 <% } %><% if (hasBody) { %><%= indentation %>  body: I<%= identifierName %>ResponseBody;

--- a/packages/types/src/templates/SharedResponse.ejs
+++ b/packages/types/src/templates/SharedResponse.ejs
@@ -17,7 +17,8 @@ import type { ITypedHttpResponse } from "<%= coreDir %>";
     export type I<%= identifierName %>ResponseBody = <%- bodyTsType %>;
 <% } %>
 
-export type I<%= identifierName %>Response = ITypedHttpResponse<
+<% if (jsDoc) { %><%- jsDoc %>
+<% } %>export type I<%= identifierName %>Response = ITypedHttpResponse<
 "<%= typeValue %>",
 HttpStatusCode.<%= statusCodeKey %>,
 <%= hasHeader ? `I${identifierName}ResponseHeader` : 'undefined' %>,


### PR DESCRIPTION
## Summary

Fix several framework issues surfaced while validating the external docs examples. Generated clients now send the headers required by their specs, typed response object literals match runtime behavior, generated artifacts expose spec summaries/descriptions as JSDoc, and thrown typed responses consistently pass through server HTTP-response error handling before final validation.

## Changes

- Default exact `z.literal(...)` request headers in generated `RequestCommand` classes so spec-declared `Accept` / `Content-Type` literals no longer need to be repeated by callers.
- Add `Content-Type: application/json` in `ApiClient` when Typeweaver JSON-serializes a request body and the caller did not provide a content-type header.
- Keep native fetch bodies untouched, including `FormData`, `Blob`, `URLSearchParams`, `ArrayBuffer`, typed arrays, `ReadableStream`, strings, `null`, and `undefined`.
- Make `ITypedHttpResponse.header` optional when the generated response has no header schema, matching the runtime normalization behavior.
- Emit sanitized JSDoc from operation summaries and response descriptions across generated request, response, client, server, Hono, and AWS CDK artifacts.
- Route thrown typed responses through `handleHttpResponseErrors` before validating the transformed response.
- Clarify that custom `handleUnknownErrors` owns its own reporting; `onError` remains used by the default unknown handler and safety net.
- Add a patch changeset and regenerate checked-in test project output.

## Test Plan

- `pnpm --filter @rexeus/typeweaver test:gen`
- `pnpm --filter test-utils test:gen`
- `pnpm -r typecheck`
- `pnpm lint`
- `pnpm -r build`
- `pnpm -r test`
- `git diff --check`