### PR TITLE
fix(gen): sandbox generated plugin writes

### DIFF
--- a/.changeset/gold-radios-grin.md
+++ b/.changeset/gold-radios-grin.md
@@ -1,0 +1,7 @@
+---
+"@rexeus/typeweaver-gen": patch
+---
+
+Harden generator plugin file writes so unsafe paths cannot escape the configured output directory.
+
+Generated plugin writes and manually tracked files now reject traversal, absolute, Windows drive/rooted/UNC, symlink, directory-like, and output-root paths. Existing generated files are replaced through a temporary file and rename so hardlinked files outside the output directory are not mutated.

--- a/packages/gen/__test__/pluginContext.test.ts
+++ b/packages/gen/__test__/pluginContext.test.ts
@@ -72,6 +72,213 @@ const aTempDir = (): string => {
   return tempDir;
 };
 
+type FileSystemError = Error & {
+  readonly code?: string;
+};
+
+const isSymlinkUnsupportedError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return ["EACCES", "EINVAL", "ENOTSUP", "EPERM"].includes(
+    (error as FileSystemError).code ?? ""
+  );
+};
+
+const isHardlinkUnsupportedError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return [
+    "EACCES",
+    "EINVAL",
+    "ENOSYS",
+    "ENOTSUP",
+    "EOPNOTSUPP",
+    "EPERM",
+  ].includes((error as FileSystemError).code ?? "");
+};
+
+const isFileModeUnsupportedError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return [
+    "EACCES",
+    "EINVAL",
+    "ENOSYS",
+    "ENOTSUP",
+    "EOPNOTSUPP",
+    "EPERM",
+  ].includes((error as FileSystemError).code ?? "");
+};
+
+type SymlinkCapability =
+  | { readonly supported: true }
+  | { readonly supported: false; readonly reason: string };
+
+const detectSymlinkCapability = (): SymlinkCapability => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "typeweaver-gen-symlink-")
+  );
+
+  try {
+    const targetDir = path.join(tempDir, "target");
+    fs.mkdirSync(targetDir);
+    fs.symlinkSync(targetDir, path.join(tempDir, "link"), "dir");
+
+    return { supported: true };
+  } catch (error) {
+    if (isSymlinkUnsupportedError(error)) {
+      const errorCode = (error as FileSystemError).code;
+
+      return {
+        supported: false,
+        reason: `symlink creation failed with ${errorCode}`,
+      };
+    }
+
+    throw error;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+};
+
+const symlinkCapability = detectSymlinkCapability();
+const symlinkSkipReason = symlinkCapability.supported
+  ? ""
+  : ` (${symlinkCapability.reason})`;
+
+type HardlinkCapability =
+  | { readonly supported: true }
+  | { readonly supported: false; readonly reason: string };
+
+const detectHardlinkCapability = (): HardlinkCapability => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "typeweaver-gen-hardlink-")
+  );
+
+  try {
+    const targetFile = path.join(tempDir, "target.ts");
+    const linkedFile = path.join(tempDir, "linked.ts");
+    fs.writeFileSync(targetFile, "export const target = true;\n");
+    fs.linkSync(targetFile, linkedFile);
+
+    if (fs.statSync(targetFile).nlink < 2) {
+      return {
+        supported: false,
+        reason: "hardlink creation did not increase link count",
+      };
+    }
+
+    return { supported: true };
+  } catch (error) {
+    if (isHardlinkUnsupportedError(error)) {
+      const errorCode = (error as FileSystemError).code;
+
+      return {
+        supported: false,
+        reason: `hardlink creation failed with ${errorCode}`,
+      };
+    }
+
+    throw error;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+};
+
+const hardlinkCapability = detectHardlinkCapability();
+const hardlinkSkipReason = hardlinkCapability.supported
+  ? ""
+  : ` (${hardlinkCapability.reason})`;
+
+type FileModeCapability =
+  | { readonly supported: true }
+  | { readonly supported: false; readonly reason: string };
+
+const detectFileModeCapability = (): FileModeCapability => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "typeweaver-gen-mode-")
+  );
+
+  try {
+    const filePath = path.join(tempDir, "generated.ts");
+    fs.writeFileSync(filePath, "export const generated = false;\n");
+    fs.chmodSync(filePath, 0o600);
+
+    const fileMode = fs.statSync(filePath).mode & 0o777;
+
+    if (fileMode !== 0o600) {
+      return {
+        supported: false,
+        reason: `chmod produced mode ${fileMode.toString(8)}`,
+      };
+    }
+
+    return { supported: true };
+  } catch (error) {
+    if (isFileModeUnsupportedError(error)) {
+      const errorCode = (error as FileSystemError).code;
+
+      return {
+        supported: false,
+        reason: `chmod failed with ${errorCode}`,
+      };
+    }
+
+    throw error;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+};
+
+const fileModeCapability = detectFileModeCapability();
+const fileModeSkipReason = fileModeCapability.supported
+  ? ""
+  : ` (${fileModeCapability.reason})`;
+
+const catchThrownError = (operation: () => void): unknown => {
+  try {
+    operation();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("Expected operation to throw.");
+};
+
+const expectUnsafeGeneratedFilePath = (operation: () => void): void => {
+  const error = catchThrownError(operation);
+
+  expect(error).toBeInstanceOf(Error);
+
+  if (!(error instanceof Error)) {
+    return;
+  }
+
+  expect(error.message).toContain("Unsafe generated file path");
+  expect(error.message).toContain(
+    "Generated writes must stay inside the output directory."
+  );
+};
+
+const outputDirWithInternalSymlink = (): {
+  readonly outputDir: string;
+  readonly targetDir: string;
+} => {
+  const outputDir = aTempDir();
+  const targetDir = path.join(outputDir, "target");
+  const linkedDir = path.join(outputDir, "linked");
+  fs.mkdirSync(targetDir);
+  fs.symlinkSync(targetDir, linkedDir, "dir");
+
+  return { outputDir, targetDir };
+};
+
 describe("createPluginContextBuilder", () => {
   afterEach(() => {
     for (const tempDir of tempDirs.splice(0)) {
@@ -324,6 +531,524 @@ describe("createPluginContextBuilder", () => {
     );
     expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
   });
+
+  test("overwrites existing generated files and records them", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+    const generatedFile = path.join("todo", "GetTodoClient.ts");
+    const generatedFilePath = path.join(outputDir, generatedFile);
+    fs.mkdirSync(path.dirname(generatedFilePath), { recursive: true });
+    fs.writeFileSync(generatedFilePath, "export const client = false;\n");
+
+    generatorContext.writeFile(generatedFile, "export const client = true;\n");
+
+    expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
+      "export const client = true;\n"
+    );
+    expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
+  });
+
+  test.skipIf(!fileModeCapability.supported)(
+    `preserves existing generated file mode when replacing it${fileModeSkipReason}`,
+    () => {
+      const outputDir = aTempDir();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+      const generatedFile = path.join("todo", "GetTodoClient.ts");
+      const generatedFilePath = path.join(outputDir, generatedFile);
+      fs.mkdirSync(path.dirname(generatedFilePath), { recursive: true });
+      fs.writeFileSync(generatedFilePath, "export const client = false;\n");
+      fs.chmodSync(generatedFilePath, 0o600);
+      const originalMode = fs.statSync(generatedFilePath).mode & 0o777;
+
+      generatorContext.writeFile(
+        generatedFile,
+        "export const client = true;\n"
+      );
+
+      expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
+        "export const client = true;\n"
+      );
+      expect(fs.statSync(generatedFilePath).mode & 0o777).toBe(originalMode);
+      expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
+    }
+  );
+
+  test.skipIf(!hardlinkCapability.supported)(
+    `replaces generated hardlink targets without mutating external files${hardlinkSkipReason}`,
+    () => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      const externalDir = path.join(workspaceDir, "external");
+      const generatedFile = path.join("todo", "Generated.ts");
+      const generatedFilePath = path.join(outputDir, generatedFile);
+      const externalFilePath = path.join(externalDir, "shared.ts");
+      fs.mkdirSync(path.dirname(generatedFilePath), { recursive: true });
+      fs.mkdirSync(externalDir);
+      fs.writeFileSync(externalFilePath, "export const sentinel = true;\n");
+      fs.linkSync(externalFilePath, generatedFilePath);
+
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      generatorContext.writeFile(
+        generatedFile,
+        "export const generated = true;\n"
+      );
+
+      expect(fs.readFileSync(externalFilePath, "utf8")).toBe(
+        "export const sentinel = true;\n"
+      );
+      expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
+        "export const generated = true;\n"
+      );
+      expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
+    }
+  );
+
+  test("normalizes current-directory segments before writing and recording generated files", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+    const generatedFile = path.join("todo", "GetTodoClient.ts");
+
+    generatorContext.writeFile(
+      "todo/./GetTodoClient.ts",
+      "export const client = true;\n"
+    );
+
+    expect(fs.readFileSync(path.join(outputDir, generatedFile), "utf8")).toBe(
+      "export const client = true;\n"
+    );
+    expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
+  });
+
+  test("writes safely when the configured output directory does not exist yet", () => {
+    const workspaceDir = aTempDir();
+    const outputDir = path.join(workspaceDir, "generated");
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+    const generatedFile = path.join("todo", "GetTodoClient.ts");
+
+    generatorContext.writeFile(generatedFile, "export const client = true;\n");
+
+    expect(fs.readFileSync(path.join(outputDir, generatedFile), "utf8")).toBe(
+      "export const client = true;\n"
+    );
+    expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
+  });
+
+  test("leaves output unchanged when replacing an existing directory target fails", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+    fs.mkdirSync(path.join(outputDir, "todo"));
+
+    const writeDirectoryTarget = () =>
+      generatorContext.writeFile("todo", "export const client = true;\n");
+
+    expect(writeDirectoryTarget).toThrowError();
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    expect(
+      fs.readdirSync(outputDir, { withFileTypes: true }).map(entry => ({
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+      }))
+    ).toEqual([{ name: "todo", isDirectory: true }]);
+  });
+
+  test("rejects parent traversal paths before writing outside the output directory", () => {
+    const workspaceDir = aTempDir();
+    const outputDir = path.join(workspaceDir, "generated");
+    fs.mkdirSync(outputDir);
+    const outsideFile = path.join(workspaceDir, "outside.ts");
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const writeOutside = () =>
+      generatorContext.writeFile(
+        "../outside.ts",
+        "export const outside = true;\n"
+      );
+
+    expectUnsafeGeneratedFilePath(writeOutside);
+    expect(fs.existsSync(outsideFile)).toBe(false);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.each([
+    {
+      scenario: "POSIX separators",
+      pathFromOutputParent: (outputDirName: string) =>
+        `../${outputDirName}/todo/File.ts`,
+    },
+    {
+      scenario: "Windows separators",
+      pathFromOutputParent: (outputDirName: string) =>
+        `..\\${outputDirName}\\todo\\File.ts`,
+    },
+    {
+      scenario: "mixed separators",
+      pathFromOutputParent: (outputDirName: string) =>
+        `../${outputDirName}\\todo/File.ts`,
+    },
+  ])(
+    "rejects $scenario traversal paths that re-enter the output directory before writing",
+    ({ pathFromOutputParent }) => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      fs.mkdirSync(outputDir);
+      const targetFile = path.join(outputDir, "todo", "File.ts");
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const writeReenteredOutput = () =>
+        generatorContext.writeFile(
+          pathFromOutputParent(path.basename(outputDir)),
+          "export const reentered = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeReenteredOutput);
+      expect(fs.existsSync(targetFile)).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test("rejects absolute POSIX paths before writing outside the output directory", () => {
+    const workspaceDir = aTempDir();
+    const outputDir = path.join(workspaceDir, "generated");
+    fs.mkdirSync(outputDir);
+    const outsideFile = path.join(workspaceDir, "outside.ts");
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const writeOutside = () =>
+      generatorContext.writeFile(outsideFile, "export const outside = true;\n");
+
+    expectUnsafeGeneratedFilePath(writeOutside);
+    expect(fs.existsSync(outsideFile)).toBe(false);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.each([
+    { scenario: "drive absolute", generatedPath: "C:\\tmp\\outside.ts" },
+    { scenario: "drive relative", generatedPath: "C:tmp\\outside.ts" },
+    { scenario: "rooted", generatedPath: "\\tmp\\outside.ts" },
+    {
+      scenario: "UNC share",
+      generatedPath: "\\\\server\\share\\outside.ts",
+    },
+  ])("rejects Windows-style $scenario paths", ({ generatedPath }) => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const writeOutside = () =>
+      generatorContext.writeFile(
+        generatedPath,
+        "export const outside = true;\n"
+      );
+
+    expectUnsafeGeneratedFilePath(writeOutside);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.each([
+    { scenario: "empty", generatedPath: "" },
+    { scenario: "current-directory", generatedPath: "." },
+    { scenario: "current-directory segment", generatedPath: "./" },
+    {
+      scenario: "directory that normalizes to current",
+      generatedPath: "todo/..",
+    },
+  ])("rejects $scenario generated file paths", ({ generatedPath }) => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const writeOutputRoot = () =>
+      generatorContext.writeFile(
+        generatedPath,
+        "export const invalid = true;\n"
+      );
+
+    expectUnsafeGeneratedFilePath(writeOutputRoot);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test("rejects traversal paths that normalize outside the output directory", () => {
+    const workspaceDir = aTempDir();
+    const outputDir = path.join(workspaceDir, "generated");
+    fs.mkdirSync(outputDir);
+    const outsideFile = path.join(workspaceDir, "outside.ts");
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const writeOutside = () =>
+      generatorContext.writeFile(
+        "todo/../../outside.ts",
+        "export const outside = true;\n"
+      );
+
+    expectUnsafeGeneratedFilePath(writeOutside);
+    expect(fs.existsSync(outsideFile)).toBe(false);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.each([
+    {
+      scenario: "single Windows parent segment",
+      generatedPath: "..\\outside.ts",
+    },
+    {
+      scenario: "nested mixed separators",
+      generatedPath: "todo\\..\\..\\outside.ts",
+    },
+  ])("rejects $scenario traversal paths", ({ generatedPath }) => {
+    const workspaceDir = aTempDir();
+    const outputDir = path.join(workspaceDir, "generated");
+    fs.mkdirSync(outputDir);
+    const outsideFile = path.join(workspaceDir, "outside.ts");
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const writeOutside = () =>
+      generatorContext.writeFile(
+        generatedPath,
+        "export const outside = true;\n"
+      );
+
+    expectUnsafeGeneratedFilePath(writeOutside);
+    expect(fs.existsSync(outsideFile)).toBe(false);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects symlink directory components before writing outside the output directory${symlinkSkipReason}`,
+    () => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      const externalDir = path.join(workspaceDir, "external");
+      const symlinkDir = path.join(outputDir, "linked");
+      const externalFile = path.join(externalDir, "outside.ts");
+      fs.mkdirSync(outputDir);
+      fs.mkdirSync(externalDir);
+      fs.symlinkSync(externalDir, symlinkDir, "dir");
+
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const writeOutside = () =>
+        generatorContext.writeFile(
+          "linked/outside.ts",
+          "export const outside = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeOutside);
+      expect(fs.existsSync(externalFile)).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects dangling final-path symlinks before writing outside the output directory${symlinkSkipReason}`,
+    () => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      const outsideFile = path.join(workspaceDir, "missing", "outside.ts");
+      fs.mkdirSync(outputDir);
+      fs.symlinkSync(outsideFile, path.join(outputDir, "outside.ts"), "file");
+
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const writeOutside = () =>
+        generatorContext.writeFile(
+          "outside.ts",
+          "export const outside = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeOutside);
+      expect(fs.existsSync(outsideFile)).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects final-path file symlinks before truncating outside files${symlinkSkipReason}`,
+    () => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      const externalDir = path.join(workspaceDir, "external");
+      const externalFile = path.join(externalDir, "outside.ts");
+      fs.mkdirSync(outputDir);
+      fs.mkdirSync(externalDir);
+      fs.writeFileSync(externalFile, "export const outside = false;\n");
+      fs.symlinkSync(externalFile, path.join(outputDir, "outside.ts"), "file");
+
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const writeOutside = () =>
+        generatorContext.writeFile(
+          "outside.ts",
+          "export const outside = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeOutside);
+      expect(fs.readFileSync(externalFile, "utf8")).toBe(
+        "export const outside = false;\n"
+      );
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects safe internal directory symlinks before writing inside the output directory${symlinkSkipReason}`,
+    () => {
+      const { outputDir, targetDir } = outputDirWithInternalSymlink();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+      const targetFile = path.join(targetDir, "GetTodoClient.ts");
+
+      const writeThroughInternalSymlink = () =>
+        generatorContext.writeFile(
+          "linked/GetTodoClient.ts",
+          "export const client = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeThroughInternalSymlink);
+      expect(fs.existsSync(targetFile)).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects existing output-root symlinks before writing generated files${symlinkSkipReason}`,
+    () => {
+      const workspaceDir = aTempDir();
+      const targetOutputDir = path.join(workspaceDir, "target-generated");
+      const outputDir = path.join(workspaceDir, "generated");
+      const targetFile = path.join(targetOutputDir, "todo", "GetTodoClient.ts");
+      fs.mkdirSync(targetOutputDir);
+      fs.symlinkSync(targetOutputDir, outputDir, "dir");
+
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const writeThroughOutputRootSymlink = () =>
+        generatorContext.writeFile(
+          path.join("todo", "GetTodoClient.ts"),
+          "export const client = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeThroughOutputRootSymlink);
+      expect(fs.existsSync(targetFile)).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects safe internal symlink paths before tracking generated files${symlinkSkipReason}`,
+    () => {
+      const { outputDir } = outputDirWithInternalSymlink();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackInternalSymlinkPath = () =>
+        generatorContext.addGeneratedFile("linked/GetTodoClient.ts");
+
+      expectUnsafeGeneratedFilePath(trackInternalSymlinkPath);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.skipIf(!symlinkCapability.supported)(
+    `rejects existing output-root symlinks before tracking generated files${symlinkSkipReason}`,
+    () => {
+      const workspaceDir = aTempDir();
+      const targetOutputDir = path.join(workspaceDir, "target-generated");
+      const outputDir = path.join(workspaceDir, "generated");
+      fs.mkdirSync(targetOutputDir);
+      fs.symlinkSync(targetOutputDir, outputDir, "dir");
+
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackOutputRootSymlinkPath = () =>
+        generatorContext.addGeneratedFile(
+          path.join("todo", "GetTodoClient.ts")
+        );
+
+      expectUnsafeGeneratedFilePath(trackOutputRootSymlinkPath);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test("rejects unsafe generated file tracking paths", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const trackUnsafePath = () =>
+      generatorContext.addGeneratedFile("../outside.ts");
+
+    expectUnsafeGeneratedFilePath(trackUnsafePath);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.each([
+    {
+      scenario: "POSIX separators",
+      pathFromOutputParent: (outputDirName: string) =>
+        `../${outputDirName}/todo/File.ts`,
+    },
+    {
+      scenario: "Windows separators",
+      pathFromOutputParent: (outputDirName: string) =>
+        `..\\${outputDirName}\\todo\\File.ts`,
+    },
+    {
+      scenario: "mixed separators",
+      pathFromOutputParent: (outputDirName: string) =>
+        `../${outputDirName}\\todo/File.ts`,
+    },
+  ])(
+    "rejects $scenario traversal paths that re-enter the output directory before tracking generated files",
+    ({ pathFromOutputParent }) => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      fs.mkdirSync(outputDir);
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackReenteredOutput = () =>
+        generatorContext.addGeneratedFile(
+          pathFromOutputParent(path.basename(outputDir))
+        );
+
+      expectUnsafeGeneratedFilePath(trackReenteredOutput);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test("normalizes current-directory segments before tracking generated files", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    generatorContext.addGeneratedFile("todo/./GetTodoClient.ts");
+
+    expect(generatorContext.getGeneratedFiles()).toEqual([
+      "todo/GetTodoClient.ts",
+    ]);
+  });
+
+  test.each([
+    { scenario: "Windows traversal", generatedPath: "..\\outside.ts" },
+    {
+      scenario: "nested Windows traversal",
+      generatedPath: "todo\\..\\..\\outside.ts",
+    },
+    { scenario: "Windows rooted", generatedPath: "\\tmp\\outside.ts" },
+    {
+      scenario: "UNC share",
+      generatedPath: "\\\\server\\share\\outside.ts",
+    },
+    { scenario: "drive-relative", generatedPath: "C:tmp\\outside.ts" },
+  ])(
+    "rejects unsafe $scenario paths when tracking generated files",
+    ({ generatedPath }) => {
+      const workspaceDir = aTempDir();
+      const outputDir = path.join(workspaceDir, "generated");
+      fs.mkdirSync(outputDir);
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackUnsafePath = () =>
+        generatorContext.addGeneratedFile(generatedPath);
+
+      expectUnsafeGeneratedFilePath(trackUnsafePath);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
 
   test("returns defensive arrays for generated file tracking", () => {
     const generatorContext = aGeneratedProjectContext();

--- a/packages/gen/__test__/pluginContext.test.ts
+++ b/packages/gen/__test__/pluginContext.test.ts
@@ -72,48 +72,46 @@ const aTempDir = (): string => {
   return tempDir;
 };
 
+const nativeGeneratedFilePath = (
+  outputDir: string,
+  generatedFile: string
+): string => path.join(outputDir, ...generatedFile.split("/"));
+
 type FileSystemError = Error & {
   readonly code?: string;
 };
 
-const isSymlinkUnsupportedError = (error: unknown): boolean => {
+const UNSUPPORTED_FILESYSTEM_OPERATION_CODES = [
+  "EACCES",
+  "EINVAL",
+  "ENOSYS",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+] as const;
+
+const isUnsupportedFilesystemOperationError = (error: unknown): boolean => {
   if (!(error instanceof Error)) {
     return false;
   }
 
-  return ["EACCES", "EINVAL", "ENOTSUP", "EPERM"].includes(
-    (error as FileSystemError).code ?? ""
+  const errorCode = (error as FileSystemError).code;
+
+  return UNSUPPORTED_FILESYSTEM_OPERATION_CODES.some(
+    unsupportedCode => unsupportedCode === errorCode
   );
 };
 
-const isHardlinkUnsupportedError = (error: unknown): boolean => {
-  if (!(error instanceof Error)) {
-    return false;
-  }
+const isSymlinkUnsupportedError = (error: unknown): boolean => {
+  return isUnsupportedFilesystemOperationError(error);
+};
 
-  return [
-    "EACCES",
-    "EINVAL",
-    "ENOSYS",
-    "ENOTSUP",
-    "EOPNOTSUPP",
-    "EPERM",
-  ].includes((error as FileSystemError).code ?? "");
+const isHardlinkUnsupportedError = (error: unknown): boolean => {
+  return isUnsupportedFilesystemOperationError(error);
 };
 
 const isFileModeUnsupportedError = (error: unknown): boolean => {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return [
-    "EACCES",
-    "EINVAL",
-    "ENOSYS",
-    "ENOTSUP",
-    "EOPNOTSUPP",
-    "EPERM",
-  ].includes((error as FileSystemError).code ?? "");
+  return isUnsupportedFilesystemOperationError(error);
 };
 
 type SymlinkCapability =
@@ -522,11 +520,12 @@ describe("createPluginContextBuilder", () => {
   test("writes files relative to the generator output directory and records them", () => {
     const outputDir = aTempDir();
     const generatorContext = aGeneratedProjectContext({ outputDir });
-    const generatedFile = path.join("todo", "GetTodoClient.ts");
+    const generatedFile = "todo/GetTodoClient.ts";
+    const generatedFilePath = nativeGeneratedFilePath(outputDir, generatedFile);
 
     generatorContext.writeFile(generatedFile, "export const client = true;\n");
 
-    expect(fs.readFileSync(path.join(outputDir, generatedFile), "utf8")).toBe(
+    expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
       "export const client = true;\n"
     );
     expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
@@ -535,8 +534,8 @@ describe("createPluginContextBuilder", () => {
   test("overwrites existing generated files and records them", () => {
     const outputDir = aTempDir();
     const generatorContext = aGeneratedProjectContext({ outputDir });
-    const generatedFile = path.join("todo", "GetTodoClient.ts");
-    const generatedFilePath = path.join(outputDir, generatedFile);
+    const generatedFile = "todo/GetTodoClient.ts";
+    const generatedFilePath = nativeGeneratedFilePath(outputDir, generatedFile);
     fs.mkdirSync(path.dirname(generatedFilePath), { recursive: true });
     fs.writeFileSync(generatedFilePath, "export const client = false;\n");
 
@@ -553,8 +552,11 @@ describe("createPluginContextBuilder", () => {
     () => {
       const outputDir = aTempDir();
       const generatorContext = aGeneratedProjectContext({ outputDir });
-      const generatedFile = path.join("todo", "GetTodoClient.ts");
-      const generatedFilePath = path.join(outputDir, generatedFile);
+      const generatedFile = "todo/GetTodoClient.ts";
+      const generatedFilePath = nativeGeneratedFilePath(
+        outputDir,
+        generatedFile
+      );
       fs.mkdirSync(path.dirname(generatedFilePath), { recursive: true });
       fs.writeFileSync(generatedFilePath, "export const client = false;\n");
       fs.chmodSync(generatedFilePath, 0o600);
@@ -579,8 +581,11 @@ describe("createPluginContextBuilder", () => {
       const workspaceDir = aTempDir();
       const outputDir = path.join(workspaceDir, "generated");
       const externalDir = path.join(workspaceDir, "external");
-      const generatedFile = path.join("todo", "Generated.ts");
-      const generatedFilePath = path.join(outputDir, generatedFile);
+      const generatedFile = "todo/Generated.ts";
+      const generatedFilePath = nativeGeneratedFilePath(
+        outputDir,
+        generatedFile
+      );
       const externalFilePath = path.join(externalDir, "shared.ts");
       fs.mkdirSync(path.dirname(generatedFilePath), { recursive: true });
       fs.mkdirSync(externalDir);
@@ -607,14 +612,32 @@ describe("createPluginContextBuilder", () => {
   test("normalizes current-directory segments before writing and recording generated files", () => {
     const outputDir = aTempDir();
     const generatorContext = aGeneratedProjectContext({ outputDir });
-    const generatedFile = path.join("todo", "GetTodoClient.ts");
+    const generatedFile = "todo/GetTodoClient.ts";
+    const generatedFilePath = nativeGeneratedFilePath(outputDir, generatedFile);
 
     generatorContext.writeFile(
       "todo/./GetTodoClient.ts",
       "export const client = true;\n"
     );
 
-    expect(fs.readFileSync(path.join(outputDir, generatedFile), "utf8")).toBe(
+    expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
+      "export const client = true;\n"
+    );
+    expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
+  });
+
+  test("normalizes Windows separators before writing and recording generated files", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+    const generatedFile = "todo/GetTodoClient.ts";
+    const generatedFilePath = nativeGeneratedFilePath(outputDir, generatedFile);
+
+    generatorContext.writeFile(
+      "todo\\GetTodoClient.ts",
+      "export const client = true;\n"
+    );
+
+    expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
       "export const client = true;\n"
     );
     expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
@@ -624,11 +647,12 @@ describe("createPluginContextBuilder", () => {
     const workspaceDir = aTempDir();
     const outputDir = path.join(workspaceDir, "generated");
     const generatorContext = aGeneratedProjectContext({ outputDir });
-    const generatedFile = path.join("todo", "GetTodoClient.ts");
+    const generatedFile = "todo/GetTodoClient.ts";
+    const generatedFilePath = nativeGeneratedFilePath(outputDir, generatedFile);
 
     generatorContext.writeFile(generatedFile, "export const client = true;\n");
 
-    expect(fs.readFileSync(path.join(outputDir, generatedFile), "utf8")).toBe(
+    expect(fs.readFileSync(generatedFilePath, "utf8")).toBe(
       "export const client = true;\n"
     );
     expect(generatorContext.getGeneratedFiles()).toEqual([generatedFile]);
@@ -669,6 +693,59 @@ describe("createPluginContextBuilder", () => {
     expect(fs.existsSync(outsideFile)).toBe(false);
     expect(generatorContext.getGeneratedFiles()).toEqual([]);
   });
+
+  test.each([
+    { scenario: "POSIX separators", generatedPath: "todo/../File.ts" },
+    { scenario: "Windows separators", generatedPath: "todo\\..\\File.ts" },
+  ])(
+    "rejects $scenario traversal paths that normalize back inside before writing",
+    ({ generatedPath }) => {
+      const outputDir = aTempDir();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+      const normalizedTargetFile = path.join(outputDir, "File.ts");
+      const nestedTargetFile = path.join(outputDir, "todo", "File.ts");
+
+      const writeNormalizedInsidePath = () =>
+        generatorContext.writeFile(
+          generatedPath,
+          "export const file = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeNormalizedInsidePath);
+      expect(fs.existsSync(normalizedTargetFile)).toBe(false);
+      expect(fs.existsSync(nestedTargetFile)).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.each([
+    { scenario: "POSIX trailing slash", generatedPath: "todo/" },
+    { scenario: "Windows trailing slash", generatedPath: "todo\\" },
+    {
+      scenario: "POSIX final current-directory segment",
+      generatedPath: "todo/.",
+    },
+    {
+      scenario: "Windows final current-directory segment",
+      generatedPath: "todo\\.",
+    },
+  ])(
+    "rejects $scenario directory-like paths before writing",
+    ({ generatedPath }) => {
+      const outputDir = aTempDir();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const writeDirectoryLikePath = () =>
+        generatorContext.writeFile(
+          generatedPath,
+          "export const directoryLike = true;\n"
+        );
+
+      expectUnsafeGeneratedFilePath(writeDirectoryLikePath);
+      expect(fs.existsSync(path.join(outputDir, "todo"))).toBe(false);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
 
   test.each([
     {
@@ -978,6 +1055,83 @@ describe("createPluginContextBuilder", () => {
   });
 
   test.each([
+    { scenario: "empty", generatedPath: "" },
+    { scenario: "current-directory", generatedPath: "." },
+    { scenario: "current-directory segment", generatedPath: "./" },
+    {
+      scenario: "directory that normalizes to current",
+      generatedPath: "todo/..",
+    },
+  ])(
+    "rejects $scenario generated file paths before tracking",
+    ({ generatedPath }) => {
+      const outputDir = aTempDir();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackOutputRoot = () =>
+        generatorContext.addGeneratedFile(generatedPath);
+
+      expectUnsafeGeneratedFilePath(trackOutputRoot);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test("rejects absolute POSIX paths before tracking generated files", () => {
+    const workspaceDir = aTempDir();
+    const outputDir = path.join(workspaceDir, "generated");
+    fs.mkdirSync(outputDir);
+    const outsideFile = path.join(workspaceDir, "outside.ts");
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    const trackOutside = () => generatorContext.addGeneratedFile(outsideFile);
+
+    expectUnsafeGeneratedFilePath(trackOutside);
+    expect(generatorContext.getGeneratedFiles()).toEqual([]);
+  });
+
+  test.each([
+    { scenario: "POSIX separators", generatedPath: "todo/../File.ts" },
+    { scenario: "Windows separators", generatedPath: "todo\\..\\File.ts" },
+  ])(
+    "rejects $scenario traversal paths that normalize back inside before tracking generated files",
+    ({ generatedPath }) => {
+      const outputDir = aTempDir();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackNormalizedInsidePath = () =>
+        generatorContext.addGeneratedFile(generatedPath);
+
+      expectUnsafeGeneratedFilePath(trackNormalizedInsidePath);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.each([
+    { scenario: "POSIX trailing slash", generatedPath: "todo/" },
+    { scenario: "Windows trailing slash", generatedPath: "todo\\" },
+    {
+      scenario: "POSIX final current-directory segment",
+      generatedPath: "todo/.",
+    },
+    {
+      scenario: "Windows final current-directory segment",
+      generatedPath: "todo\\.",
+    },
+  ])(
+    "rejects $scenario directory-like paths before tracking generated files",
+    ({ generatedPath }) => {
+      const outputDir = aTempDir();
+      const generatorContext = aGeneratedProjectContext({ outputDir });
+
+      const trackDirectoryLikePath = () =>
+        generatorContext.addGeneratedFile(generatedPath);
+
+      expectUnsafeGeneratedFilePath(trackDirectoryLikePath);
+      expect(generatorContext.getGeneratedFiles()).toEqual([]);
+    }
+  );
+
+  test.each([
     {
       scenario: "POSIX separators",
       pathFromOutputParent: (outputDirName: string) =>
@@ -1016,6 +1170,17 @@ describe("createPluginContextBuilder", () => {
     const generatorContext = aGeneratedProjectContext({ outputDir });
 
     generatorContext.addGeneratedFile("todo/./GetTodoClient.ts");
+
+    expect(generatorContext.getGeneratedFiles()).toEqual([
+      "todo/GetTodoClient.ts",
+    ]);
+  });
+
+  test("normalizes Windows separators before tracking generated files", () => {
+    const outputDir = aTempDir();
+    const generatorContext = aGeneratedProjectContext({ outputDir });
+
+    generatorContext.addGeneratedFile("todo\\GetTodoClient.ts");
 
     expect(generatorContext.getGeneratedFiles()).toEqual([
       "todo/GetTodoClient.ts",

--- a/packages/gen/src/plugins/pluginContext.ts
+++ b/packages/gen/src/plugins/pluginContext.ts
@@ -127,10 +127,7 @@ function assertPathStatsIsNotSymlink(
     return;
   }
 
-  throwUnsafeGeneratedFilePath(
-    requestedPath,
-    "path contains a symbolic link"
-  );
+  throwUnsafeGeneratedFilePath(requestedPath, "path contains a symbolic link");
 }
 
 function getExistingPathStats(absolutePath: string): fs.Stats | undefined {
@@ -150,9 +147,7 @@ function isMissingPathError(error: unknown): boolean {
     return false;
   }
 
-  return ["ENOENT", "ENOTDIR"].includes(
-    (error as FileSystemError).code ?? ""
-  );
+  return ["ENOENT", "ENOTDIR"].includes((error as FileSystemError).code ?? "");
 }
 
 function isStrictlyInsidePath(childPath: string, parentPath: string): boolean {

--- a/packages/gen/src/plugins/pluginContext.ts
+++ b/packages/gen/src/plugins/pluginContext.ts
@@ -18,6 +18,18 @@ type FileSystemError = Error & {
 
 const WINDOWS_DRIVE_PREFIX_PATTERN = /^[a-zA-Z]:/;
 
+function pathContainsParentTraversal(projectPath: string): boolean {
+  return projectPath.split("/").includes("..");
+}
+
+function pathEndsWithDirectorySeparator(projectPath: string): boolean {
+  return projectPath.endsWith("/");
+}
+
+function pathNamesCurrentDirectory(projectPath: string): boolean {
+  return projectPath === "." || projectPath.endsWith("/.");
+}
+
 function resolveSafeGeneratedFilePath(
   outputDir: string,
   requestedPath: string
@@ -41,6 +53,27 @@ function resolveSafeGeneratedFilePath(
     );
   }
 
+  if (pathContainsParentTraversal(projectPath)) {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "path contains parent-directory traversal"
+    );
+  }
+
+  if (pathEndsWithDirectorySeparator(projectPath)) {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "path must name a file inside the output directory"
+    );
+  }
+
+  if (pathNamesCurrentDirectory(projectPath)) {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "path must name a file inside the output directory"
+    );
+  }
+
   const generatedPath = path.posix.normalize(projectPath);
 
   if (generatedPath === ".") {
@@ -50,7 +83,7 @@ function resolveSafeGeneratedFilePath(
     );
   }
 
-  if (generatedPath.split("/").includes("..")) {
+  if (pathContainsParentTraversal(generatedPath)) {
     throwUnsafeGeneratedFilePath(
       requestedPath,
       "path contains parent-directory traversal"
@@ -171,33 +204,43 @@ function throwUnsafeGeneratedFilePath(
   );
 }
 
-function revalidateGeneratedWritePathAfterMkdir(
+function revalidateGeneratedWritePath(
   outputDir: string,
   generatedPath: string
 ): SafeGeneratedFilePath {
-  // Parent directory creation can expose a symlink inserted in the write path;
-  // validate again immediately before writeFile follows the filesystem path.
   return resolveSafeGeneratedFilePath(outputDir, generatedPath);
 }
 
 function writeGeneratedFileByReplacingDestination(config: {
   readonly outputDir: string;
   readonly generatedPath: string;
-  readonly fullPath: string;
   readonly content: string;
 }): SafeGeneratedFilePath {
-  const destinationDir = path.dirname(config.fullPath);
-  const existingFileMode = getExistingFileMode(config.fullPath);
+  const existingPath = revalidateGeneratedWritePath(
+    config.outputDir,
+    config.generatedPath
+  );
+  const existingFileMode = getExistingFileMode(existingPath.fullPath);
+  const tempParentPath = revalidateGeneratedWritePath(
+    config.outputDir,
+    config.generatedPath
+  );
+  const destinationDir = path.dirname(tempParentPath.fullPath);
   const tempDir = fs.mkdtempSync(path.join(destinationDir, ".typeweaver-"));
   const tempFile = path.join(tempDir, "generated.tmp");
 
   try {
+    revalidateGeneratedWritePath(config.outputDir, config.generatedPath);
     fs.writeFileSync(tempFile, config.content, {
       flag: "wx",
       mode: existingFileMode ?? 0o666,
     });
 
-    const writablePath = revalidateGeneratedWritePathAfterMkdir(
+    if (existingFileMode !== undefined) {
+      fs.chmodSync(tempFile, existingFileMode);
+    }
+
+    const writablePath = revalidateGeneratedWritePath(
       config.outputDir,
       config.generatedPath
     );
@@ -363,14 +406,13 @@ export function createPluginContextBuilder(): PluginContextBuilderApi {
         const dir = path.dirname(safePath.fullPath);
 
         fs.mkdirSync(dir, { recursive: true });
-        const writablePath = revalidateGeneratedWritePathAfterMkdir(
+        const writablePath = revalidateGeneratedWritePath(
           params.outputDir,
           safePath.generatedPath
         );
         const generatedFile = writeGeneratedFileByReplacingDestination({
           outputDir: params.outputDir,
           generatedPath: writablePath.generatedPath,
-          fullPath: writablePath.fullPath,
           content,
         });
         generatedFiles.add(generatedFile.generatedPath);

--- a/packages/gen/src/plugins/pluginContext.ts
+++ b/packages/gen/src/plugins/pluginContext.ts
@@ -7,6 +7,223 @@ import { MissingCanonicalResponseError } from "./errors/MissingCanonicalResponse
 import type { NormalizedResponse, NormalizedSpec } from "../NormalizedSpec.js";
 import type { GeneratorContext, PluginConfig, PluginContext } from "./types.js";
 
+type SafeGeneratedFilePath = {
+  readonly fullPath: string;
+  readonly generatedPath: string;
+};
+
+type FileSystemError = Error & {
+  readonly code?: string;
+};
+
+const WINDOWS_DRIVE_PREFIX_PATTERN = /^[a-zA-Z]:/;
+
+function resolveSafeGeneratedFilePath(
+  outputDir: string,
+  requestedPath: string
+): SafeGeneratedFilePath {
+  if (requestedPath.length === 0) {
+    throwUnsafeGeneratedFilePath(requestedPath, "path must not be empty");
+  }
+
+  const projectPath = requestedPath.replace(/\\/g, "/");
+
+  if (
+    path.isAbsolute(requestedPath) ||
+    path.posix.isAbsolute(projectPath) ||
+    path.win32.isAbsolute(requestedPath) ||
+    path.win32.isAbsolute(projectPath) ||
+    WINDOWS_DRIVE_PREFIX_PATTERN.test(requestedPath)
+  ) {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "absolute paths are not allowed"
+    );
+  }
+
+  const generatedPath = path.posix.normalize(projectPath);
+
+  if (generatedPath === ".") {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "path must name a file inside the output directory"
+    );
+  }
+
+  if (generatedPath.split("/").includes("..")) {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "path contains parent-directory traversal"
+    );
+  }
+
+  const outputRoot = path.resolve(outputDir);
+  const fullPath = path.resolve(outputRoot, toNativePath(generatedPath));
+
+  if (!isStrictlyInsidePath(fullPath, outputRoot)) {
+    throwUnsafeGeneratedFilePath(
+      requestedPath,
+      "path escapes the output directory"
+    );
+  }
+
+  assertGeneratedPathHasNoSymlinkComponents({
+    outputRoot,
+    generatedPath,
+    requestedPath,
+  });
+
+  return { fullPath, generatedPath };
+}
+
+function toNativePath(projectPath: string): string {
+  return projectPath.split("/").join(path.sep);
+}
+
+function assertGeneratedPathHasNoSymlinkComponents(config: {
+  readonly outputRoot: string;
+  readonly generatedPath: string;
+  readonly requestedPath: string;
+}): void {
+  assertExistingPathIsNotSymlink(config.outputRoot, config.requestedPath);
+
+  let currentPath = config.outputRoot;
+
+  for (const segment of config.generatedPath.split("/")) {
+    currentPath = path.join(currentPath, segment);
+
+    const pathStats = getExistingPathStats(currentPath);
+
+    if (pathStats === undefined) {
+      return;
+    }
+
+    assertPathStatsIsNotSymlink(pathStats, config.requestedPath);
+
+    if (!pathStats.isDirectory()) {
+      return;
+    }
+  }
+}
+
+function assertExistingPathIsNotSymlink(
+  absolutePath: string,
+  requestedPath: string
+): void {
+  const pathStats = getExistingPathStats(absolutePath);
+
+  if (pathStats === undefined) {
+    return;
+  }
+
+  assertPathStatsIsNotSymlink(pathStats, requestedPath);
+}
+
+function assertPathStatsIsNotSymlink(
+  pathStats: fs.Stats,
+  requestedPath: string
+): void {
+  if (!pathStats.isSymbolicLink()) {
+    return;
+  }
+
+  throwUnsafeGeneratedFilePath(
+    requestedPath,
+    "path contains a symbolic link"
+  );
+}
+
+function getExistingPathStats(absolutePath: string): fs.Stats | undefined {
+  try {
+    return fs.lstatSync(absolutePath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return ["ENOENT", "ENOTDIR"].includes(
+    (error as FileSystemError).code ?? ""
+  );
+}
+
+function isStrictlyInsidePath(childPath: string, parentPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath);
+
+  return (
+    relativePath !== "" &&
+    relativePath !== ".." &&
+    !relativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
+function throwUnsafeGeneratedFilePath(
+  requestedPath: string,
+  reason: string
+): never {
+  throw new Error(
+    `Unsafe generated file path '${requestedPath}': ${reason}. ` +
+      `Generated writes must stay inside the output directory.`
+  );
+}
+
+function revalidateGeneratedWritePathAfterMkdir(
+  outputDir: string,
+  generatedPath: string
+): SafeGeneratedFilePath {
+  // Parent directory creation can expose a symlink inserted in the write path;
+  // validate again immediately before writeFile follows the filesystem path.
+  return resolveSafeGeneratedFilePath(outputDir, generatedPath);
+}
+
+function writeGeneratedFileByReplacingDestination(config: {
+  readonly outputDir: string;
+  readonly generatedPath: string;
+  readonly fullPath: string;
+  readonly content: string;
+}): SafeGeneratedFilePath {
+  const destinationDir = path.dirname(config.fullPath);
+  const existingFileMode = getExistingFileMode(config.fullPath);
+  const tempDir = fs.mkdtempSync(path.join(destinationDir, ".typeweaver-"));
+  const tempFile = path.join(tempDir, "generated.tmp");
+
+  try {
+    fs.writeFileSync(tempFile, config.content, {
+      flag: "wx",
+      mode: existingFileMode ?? 0o666,
+    });
+
+    const writablePath = revalidateGeneratedWritePathAfterMkdir(
+      config.outputDir,
+      config.generatedPath
+    );
+    fs.renameSync(tempFile, writablePath.fullPath);
+
+    return writablePath;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function getExistingFileMode(absolutePath: string): number | undefined {
+  const pathStats = getExistingPathStats(absolutePath);
+
+  if (pathStats?.isFile() !== true) {
+    return undefined;
+  }
+
+  return pathStats.mode & 0o777;
+}
+
 export type PluginContextBuilderApi = {
   readonly createPluginContext: (params: {
     outputDir: string;
@@ -144,14 +361,26 @@ export function createPluginContextBuilder(): PluginContextBuilderApi {
       getResourceOutputDir,
 
       writeFile: (relativePath: string, content: string) => {
-        const fullPath = path.join(params.outputDir, relativePath);
-        const dir = path.dirname(fullPath);
+        const safePath = resolveSafeGeneratedFilePath(
+          params.outputDir,
+          relativePath
+        );
+        const dir = path.dirname(safePath.fullPath);
 
         fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(fullPath, content);
-        generatedFiles.add(relativePath);
+        const writablePath = revalidateGeneratedWritePathAfterMkdir(
+          params.outputDir,
+          safePath.generatedPath
+        );
+        const generatedFile = writeGeneratedFileByReplacingDestination({
+          outputDir: params.outputDir,
+          generatedPath: writablePath.generatedPath,
+          fullPath: writablePath.fullPath,
+          content,
+        });
+        generatedFiles.add(generatedFile.generatedPath);
 
-        console.info(`Generated: ${relativePath}`);
+        console.info(`Generated: ${generatedFile.generatedPath}`);
       },
 
       renderTemplate: (templatePath: string, data: unknown) => {
@@ -167,7 +396,12 @@ export function createPluginContextBuilder(): PluginContextBuilderApi {
       },
 
       addGeneratedFile: (relativePath: string) => {
-        generatedFiles.add(relativePath);
+        const safePath = resolveSafeGeneratedFilePath(
+          params.outputDir,
+          relativePath
+        );
+
+        generatedFiles.add(safePath.generatedPath);
       },
 
       getGeneratedFiles: () => {


### PR DESCRIPTION
## Summary

Harden generator plugin file writes so untrusted plugin paths cannot escape the configured output directory. This prevents traversal, symlink, hardlink, and generated-file tracking bypasses from writing or recording paths outside the generator sandbox.

## Changes

- Validate `writeFile` and `addGeneratedFile` paths before writing or tracking generated files.
- Reject unsafe generated paths including:
  - empty/current-directory paths
  - POSIX absolute paths
  - Windows drive/rooted/UNC paths
  - parent-directory traversal, including traversal that exits and re-enters the output root
  - symlink components, dangling symlinks, and output-root symlinks
- Replace generated files via temp-file + rename so hardlinked destination files are not truncated through shared inodes.
- Preserve normal overwrite behavior, normalized `.` path segments, generated-file tracking, and existing file modes where supported.
- Add filesystem boundary tests covering traversal, Windows path forms, symlinks, hardlinks, failed replacement cleanup, and mode preservation.

## Test Plan

- `pnpm --filter @rexeus/typeweaver-gen test`
- `pnpm --filter @rexeus/typeweaver-gen typecheck`