### PR TITLE
feat(zod-to-ts): support wrapper schema generation

### DIFF
--- a/.changeset/shaky-results-live.md
+++ b/.changeset/shaky-results-live.md
@@ -1,0 +1,7 @@
+---
+"@rexeus/typeweaver-zod-to-ts": minor
+---
+
+Expand Zod-to-TypeScript generation for Zod v4 wrapper schemas.
+
+`z.nonoptional()`, `z.readonly()`, `z.catch()`, `z.pipe()`, `z.nan()`, `z.file()`, and `z.success()` now emit concrete TypeScript types where possible instead of falling back to `unknown`. Object property keys that are reserved identifiers or otherwise unsafe are emitted as string literal keys.

--- a/packages/zod-to-ts/README.md
+++ b/packages/zod-to-ts/README.md
@@ -49,13 +49,13 @@ The library provides complete TypeScript type generation for the following Zod s
 - **Objects**: `z.object()` with nested properties and optional fields
 - **Unions**: `z.union()`
 - **Intersections**: `z.intersection()`
-- **Modifiers**: `z.optional()`, `z.nullable()`, `z.default()`, `z.nonoptional()`,
-  `z.readonly()`, `z.catch()`
-- **Special types**: `z.unknown()`, `z.any()`, `z.void()`, `z.never()`, `z.null()`,
-  `z.undefined()`, `z.nan()`, `z.file()`, `z.success()`
+- **Modifiers**: `z.optional()`, `z.nullable()`, `z.default()`, `z.nonoptional()`, `z.readonly()`,
+  `z.catch()`
+- **Special types**: `z.unknown()`, `z.any()`, `z.void()`, `z.never()`, `z.null()`, `z.undefined()`,
+  `z.nan()`, `z.file()`, `z.success()`
 - **Async types**: `z.promise()`
-- **Pipes**: `z.pipe()` outputs the pipe output schema type; unsupported output schemas
-  still fall back to `unknown`
+- **Pipes**: `z.pipe()` outputs the pipe output schema type; unsupported output schemas still fall
+  back to `unknown`
 
 ### ⚠️ Unsupported Types
 

--- a/packages/zod-to-ts/README.md
+++ b/packages/zod-to-ts/README.md
@@ -49,17 +49,19 @@ The library provides complete TypeScript type generation for the following Zod s
 - **Objects**: `z.object()` with nested properties and optional fields
 - **Unions**: `z.union()`
 - **Intersections**: `z.intersection()`
-- **Modifiers**: `z.optional()`, `z.nullable()`, `z.default()`
-- **Special types**: `z.unknown()`, `z.any()`, `z.void()`, `z.never()`, `z.null()`, `z.undefined()`
+- **Modifiers**: `z.optional()`, `z.nullable()`, `z.default()`, `z.nonoptional()`,
+  `z.readonly()`, `z.catch()`
+- **Special types**: `z.unknown()`, `z.any()`, `z.void()`, `z.never()`, `z.null()`,
+  `z.undefined()`, `z.nan()`, `z.file()`, `z.success()`
 - **Async types**: `z.promise()`
+- **Pipes**: `z.pipe()` outputs the pipe output schema type; unsupported output schemas
+  still fall back to `unknown`
 
 ### ⚠️ Unsupported Types
 
 The following Zod types are not yet implemented and will fall back to `unknown` type:
 
-- **Advanced types**: `z.lazy()`, `z.templateLiteral()`, `z.custom()`, `z.transform()`, `z.pipe()`
-- **Modifiers**: `z.nonoptional()`, `z.readonly()`, `z.catch()`
-- **Special types**: `z.nan()`, `z.file()`, `z.success()`
+- **Advanced types**: `z.lazy()`, `z.templateLiteral()`, `z.custom()`, `z.transform()`
 
 > **Note**: When encountering unsupported Zod types, the library gracefully falls back to
 > TypeScript's `unknown` type to maintain type safety.

--- a/packages/zod-to-ts/__test__/unit/tsTypeGenerator.test.ts
+++ b/packages/zod-to-ts/__test__/unit/tsTypeGenerator.test.ts
@@ -119,9 +119,86 @@ describe("object schemas", () => {
     expect(toTs(z.object({}))).toBe("{}");
   });
 
-  test("quotes object keys that are not TypeScript identifiers", () => {
-    expect(toTs(z.object({ "x-id": z.string() }))).toBe(
-      ["{", '    "x-id": string;', "}"].join("\n")
+  test.each([
+    { scenario: "default", key: "default" },
+    { scenario: "class", key: "class" },
+    { scenario: "function", key: "function" },
+    { scenario: "export", key: "export" },
+    { scenario: "extends", key: "extends" },
+    { scenario: "implements", key: "implements" },
+    { scenario: "interface", key: "interface" },
+    { scenario: "package", key: "package" },
+    { scenario: "private", key: "private" },
+    { scenario: "public", key: "public" },
+    { scenario: "return", key: "return" },
+    { scenario: "const", key: "const" },
+    { scenario: "import", key: "import" },
+  ])("quotes reserved object key $scenario", ({ key }) => {
+    expect(toTs(z.object({ [key]: z.string() }))).toBe(
+      ["{", `    "${key}": string;`, "}"].join("\n")
+    );
+  });
+
+  test.each([
+    { scenario: "hyphenated key", key: "x-id", expectedKey: '"x-id"' },
+    {
+      scenario: "header key",
+      key: "content-type",
+      expectedKey: '"content-type"',
+    },
+    { scenario: "leading number key", key: "123abc", expectedKey: '"123abc"' },
+    { scenario: "empty key", key: "", expectedKey: '""' },
+    {
+      scenario: "key with space",
+      key: "has space",
+      expectedKey: '"has space"',
+    },
+    {
+      scenario: "leading space key",
+      key: " leading",
+      expectedKey: '" leading"',
+    },
+    {
+      scenario: "trailing space key",
+      key: "trailing ",
+      expectedKey: '"trailing "',
+    },
+    { scenario: "dotted key", key: "a.b", expectedKey: '"a.b"' },
+    { scenario: "slashed key", key: "a/b", expectedKey: '"a/b"' },
+    {
+      scenario: "quoted key",
+      key: 'quote"key',
+      expectedKey: '"quote\\"key"',
+    },
+    {
+      scenario: "line break key",
+      key: "line\nbreak",
+      expectedKey: '"line\\nbreak"',
+    },
+  ])("quotes invalid object key for $scenario", ({ key, expectedKey }) => {
+    expect(toTs(z.object({ [key]: z.string() }))).toBe(
+      ["{", `    ${expectedKey}: string;`, "}"].join("\n")
+    );
+  });
+
+  test.each([
+    { scenario: "default-like key", key: "defaultValue" },
+    { scenario: "class-like key", key: "className" },
+  ])("keeps normal object key unquoted for $scenario", ({ key }) => {
+    expect(toTs(z.object({ [key]: z.string() }))).toBe(
+      ["{", `    ${key}: string;`, "}"].join("\n")
+    );
+  });
+
+  test("quotes optional reserved object keys and preserves the optional marker", () => {
+    expect(toTs(z.object({ default: z.string().optional() }))).toBe(
+      ["{", '    "default"?: string | undefined;', "}"].join("\n")
+    );
+  });
+
+  test("quotes optional invalid object keys and preserves the optional marker", () => {
+    expect(toTs(z.object({ "x-id": z.string().optional() }))).toBe(
+      ["{", '    "x-id"?: string | undefined;', "}"].join("\n")
     );
   });
 
@@ -323,9 +400,171 @@ describe("collection schemas", () => {
   });
 });
 
+describe("wrapper schemas", () => {
+  test("maps nonoptional optional schemas without undefined", () => {
+    expect(toTs(z.string().optional().nonoptional())).toBe("string");
+  });
+
+  test("maps nonoptional undefined schemas to never", () => {
+    expect(toTs(z.undefined().nonoptional())).toBe("never");
+  });
+
+  test("maps nonoptional undefined object fields to required never properties", () => {
+    expect(toTs(z.object({ value: z.undefined().nonoptional() }))).toBe(
+      ["{", "    value: never;", "}"].join("\n")
+    );
+  });
+
+  test("maps nonoptional unions without undefined", () => {
+    expect(toTs(z.union([z.string(), z.undefined()]).nonoptional())).toBe(
+      "string"
+    );
+  });
+
+  test("maps nonoptional optional object fields to required TypeScript properties", () => {
+    expect(toTs(z.object({ name: z.string().optional().nonoptional() }))).toBe(
+      ["{", "    name: string;", "}"].join("\n")
+    );
+  });
+
+  test("maps nan schemas to number", () => {
+    expect(toTs(z.nan())).toBe("number");
+  });
+
+  test("maps pipe schemas to the output schema type", () => {
+    expect(toTs(z.string().pipe(z.coerce.number()))).toBe("number");
+  });
+
+  test("maps pipe schemas with unsupported outputs to unknown", () => {
+    expect(toTs(z.string().pipe(z.transform((value) => value)))).toBe(
+      "unknown"
+    );
+  });
+
+  test("maps pipe object fields to optional properties from optional outputs", () => {
+    expect(
+      toTs(z.object({ value: z.string().pipe(z.string().optional()) }))
+    ).toBe(["{", "    value?: string | undefined;", "}"].join("\n"));
+  });
+
+  test("maps pipe object fields with unsupported outputs to unknown", () => {
+    expect(
+      toTs(z.object({ value: z.string().pipe(z.transform((value) => value)) }))
+    ).toBe(["{", "    value: unknown;", "}"].join("\n"));
+  });
+
+  test("maps success schemas to boolean", () => {
+    expect(toTs(z.success(z.string()))).toBe("boolean");
+  });
+
+  test("maps catch schemas to their inner TypeScript type", () => {
+    expect(toTs(z.string().catch("fallback"))).toBe("string");
+  });
+
+  test("maps optional catch schemas to their optional inner TypeScript type", () => {
+    expect(toTs(z.string().optional().catch("fallback"))).toBe(
+      "string | undefined"
+    );
+  });
+
+  test("maps optional catch object fields to optional TypeScript properties", () => {
+    expect(
+      toTs(z.object({ name: z.string().optional().catch("fallback") }))
+    ).toBe(["{", "    name?: string | undefined;", "}"].join("\n"));
+  });
+
+  test("maps default catch schemas to their default inner TypeScript type", () => {
+    expect(toTs(z.string().default("x").catch("fallback"))).toBe("string");
+  });
+
+  test("maps default catch object fields to required TypeScript properties", () => {
+    expect(
+      toTs(z.object({ name: z.string().default("x").catch("fallback") }))
+    ).toBe(["{", "    name: string;", "}"].join("\n"));
+  });
+
+  test("maps file schemas to File", () => {
+    expect(toTs(z.file())).toBe("File");
+  });
+
+  test.each([
+    {
+      scenario: "primitive readonly schema",
+      schema: z.string().readonly(),
+      expected: "string",
+    },
+    {
+      scenario: "literal readonly schema",
+      schema: z.literal("fixed").readonly(),
+      expected: '"fixed"',
+    },
+    {
+      scenario: "date readonly schema",
+      schema: z.date().readonly(),
+      expected: "Date",
+    },
+    {
+      scenario: "promise readonly schema",
+      schema: z.promise(z.string()).readonly(),
+      expected: "Promise<string>",
+    },
+  ])("keeps $scenario unchanged", ({ schema, expected }) => {
+    expect(toTs(schema)).toBe(expected);
+  });
+
+  test("maps readonly arrays to readonly TypeScript arrays", () => {
+    expect(toTs(z.array(z.string()).readonly())).toBe("readonly string[]");
+  });
+
+  test("maps optional readonly arrays to readonly array unions", () => {
+    expect(toTs(z.array(z.string()).optional().readonly())).toBe(
+      "readonly string[] | undefined"
+    );
+  });
+
+  test("maps readonly objects to Readonly TypeScript utility types", () => {
+    expect(toTs(z.object({ id: z.string() }).readonly())).toBe(
+      ["Readonly<{", "    id: string;", "}>"].join("\n")
+    );
+  });
+
+  test("maps nullable readonly objects to Readonly object unions", () => {
+    expect(toTs(z.object({ id: z.string() }).nullable().readonly())).toBe(
+      ["Readonly<{", "    id: string;", "}> | null"].join("\n")
+    );
+  });
+
+  test("maps readonly tuples to readonly TypeScript tuples", () => {
+    expect(toTs(z.tuple([z.string(), z.number()]).readonly())).toBe(
+      ["readonly [", "    string,", "    number", "]"].join("\n")
+    );
+  });
+
+  test("maps readonly maps to ReadonlyMap", () => {
+    expect(toTs(z.map(z.string(), z.number()).readonly())).toBe(
+      "ReadonlyMap<string, number>"
+    );
+  });
+
+  test("maps readonly records to Readonly Record utility types", () => {
+    expect(toTs(z.record(z.string(), z.number()).readonly())).toBe(
+      "Readonly<Record<string, number>>"
+    );
+  });
+
+  test("maps readonly sets to ReadonlySet", () => {
+    expect(toTs(z.set(z.string()).readonly())).toBe("ReadonlySet<string>");
+  });
+
+  test("maps readonly unions branch by branch", () => {
+    expect(
+      toTs(z.union([z.array(z.string()), z.set(z.number())]).readonly())
+    ).toBe("readonly string[] | ReadonlySet<number>");
+  });
+});
+
 describe("unsupported schemas", () => {
   test.each([
-    { scenario: "z.file()", schema: z.file() },
     { scenario: "z.lazy()", schema: z.lazy(() => z.string()) },
     {
       scenario: "z.templateLiteral()",
@@ -334,23 +573,8 @@ describe("unsupported schemas", () => {
     { scenario: "z.custom()", schema: z.custom() },
     {
       scenario: "z.transform()",
-      schema: z.string().transform(value => value.length),
+      schema: z.string().transform((value) => value.length),
     },
-    {
-      scenario: "z.pipe()",
-      schema: z.string().pipe(z.transform(value => value)),
-    },
-    {
-      scenario: "z.nonoptional()",
-      schema: z.string().optional().nonoptional(),
-    },
-    {
-      scenario: "z.readonly()",
-      schema: z.object({ id: z.string() }).readonly(),
-    },
-    { scenario: "z.nan()", schema: z.nan() },
-    { scenario: "z.catch()", schema: z.string().catch("fallback") },
-    { scenario: "z.success()", schema: z.success(z.string()) },
   ])(
     "falls back to unknown for unsupported $scenario schemas",
     ({ schema }) => {

--- a/packages/zod-to-ts/__test__/unit/tsTypeGenerator.test.ts
+++ b/packages/zod-to-ts/__test__/unit/tsTypeGenerator.test.ts
@@ -436,9 +436,7 @@ describe("wrapper schemas", () => {
   });
 
   test("maps pipe schemas with unsupported outputs to unknown", () => {
-    expect(toTs(z.string().pipe(z.transform((value) => value)))).toBe(
-      "unknown"
-    );
+    expect(toTs(z.string().pipe(z.transform(value => value)))).toBe("unknown");
   });
 
   test("maps pipe object fields to optional properties from optional outputs", () => {
@@ -449,7 +447,7 @@ describe("wrapper schemas", () => {
 
   test("maps pipe object fields with unsupported outputs to unknown", () => {
     expect(
-      toTs(z.object({ value: z.string().pipe(z.transform((value) => value)) }))
+      toTs(z.object({ value: z.string().pipe(z.transform(value => value)) }))
     ).toBe(["{", "    value: unknown;", "}"].join("\n"));
   });
 
@@ -573,7 +571,7 @@ describe("unsupported schemas", () => {
     { scenario: "z.custom()", schema: z.custom() },
     {
       scenario: "z.transform()",
-      schema: z.string().transform((value) => value.length),
+      schema: z.string().transform(value => value.length),
     },
   ])(
     "falls back to unknown for unsupported $scenario schemas",

--- a/packages/zod-to-ts/src/tsTypeGenerator.ts
+++ b/packages/zod-to-ts/src/tsTypeGenerator.ts
@@ -1,7 +1,15 @@
 import {
   factory,
+  isArrayTypeNode,
+  isIdentifier,
+  isIdentifierPart,
+  isIdentifierStart,
+  isLiteralTypeNode,
   isParenthesizedTypeNode,
+  isTupleTypeNode,
+  isTypeReferenceNode,
   isUnionTypeNode,
+  ScriptTarget,
   SyntaxKind,
 } from "typescript";
 import {
@@ -394,9 +402,16 @@ function fromZodDefault(zodDefault: $ZodDefault): TypeNode {
   return withoutUndefined(innerType);
 }
 
-function withoutUndefined(type: TypeNode): TypeNode {
+function withoutUndefined(
+  type: TypeNode,
+  fallbackType: TypeNode = type
+): TypeNode {
   if (isParenthesizedTypeNode(type)) {
-    return withoutUndefined(type.type);
+    return withoutUndefined(type.type, fallbackType);
+  }
+
+  if (type.kind === SyntaxKind.UndefinedKeyword) {
+    return fallbackType;
   }
 
   if (!isUnionTypeNode(type)) {
@@ -404,7 +419,7 @@ function withoutUndefined(type: TypeNode): TypeNode {
   }
 
   const types = type.types
-    .map(withoutUndefined)
+    .map(nextType => withoutUndefined(nextType))
     .flatMap(nextType =>
       isUnionTypeNode(nextType) ? Array.from(nextType.types) : [nextType]
     )
@@ -412,7 +427,7 @@ function withoutUndefined(type: TypeNode): TypeNode {
 
   const [singleType] = types;
   if (types.length === 0) {
-    return type;
+    return fallbackType;
   }
   if (types.length === 1 && singleType) {
     return singleType;
@@ -438,52 +453,206 @@ function fromZodTransform(_zodTransform: $ZodTransform): TypeNode {
   return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
 }
 
-function fromZodNonOptional(_zodNonOptional: $ZodNonOptional): TypeNode {
-  // TODO: handle zodNonOptional
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+function fromZodNonOptional(zodNonOptional: $ZodNonOptional): TypeNode {
+  const innerType = fromZod(zodNonOptional._zod.def.innerType);
+  return withoutUndefined(
+    innerType,
+    factory.createKeywordTypeNode(SyntaxKind.NeverKeyword)
+  );
 }
 
-function fromZodReadonly(_zodReadonly: $ZodReadonly): TypeNode {
-  // TODO: handle zodReadonly
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+function fromZodReadonly(zodReadonly: $ZodReadonly): TypeNode {
+  return createReadonlyType(fromZod(zodReadonly._zod.def.innerType));
 }
 
 function fromZodNaN(_zodNaN: $ZodNaN): TypeNode {
-  // TODO: handle zodNaN
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+  return factory.createKeywordTypeNode(SyntaxKind.NumberKeyword);
 }
 
-function fromZodPipe(_zodPipe: $ZodPipe): TypeNode {
-  // TODO: handle zodPipe
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+function fromZodPipe(zodPipe: $ZodPipe): TypeNode {
+  return fromZod(zodPipe._zod.def.out);
 }
 
 function fromZodSuccess(_zodSuccess: $ZodSuccess): TypeNode {
-  // TODO: handle zodSuccess
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+  return factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword);
 }
 
-function fromZodCatch(_zodCatch: $ZodCatch): TypeNode {
-  // TODO: handle zodCatch
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+function fromZodCatch(zodCatch: $ZodCatch): TypeNode {
+  return fromZod(zodCatch._zod.def.innerType);
 }
 
 function fromZodFile(_zodFile: $ZodFile): TypeNode {
-  return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
+  return factory.createTypeReferenceNode(factory.createIdentifier("File"));
 }
 
-/**
- * Returns a TypeScript AST node representing the property key.
- * If the key is a valid JavaScript identifier, returns an Identifier node.
- * Otherwise, returns a StringLiteral node.
- *
- * @param {string} key - The property key to convert.
- * @returns {Identifier | StringLiteral} The corresponding AST node for the property key.
- */
+function createReadonlyType(type: TypeNode): TypeNode {
+  if (isParenthesizedTypeNode(type)) {
+    return createReadonlyType(type.type);
+  }
+
+  if (isUnionTypeNode(type)) {
+    return factory.createUnionTypeNode(type.types.map(createReadonlyType));
+  }
+
+  if (isArrayTypeNode(type) || isTupleTypeNode(type)) {
+    return factory.createTypeOperatorNode(SyntaxKind.ReadonlyKeyword, type);
+  }
+
+  if (isReadonlyPrimitiveType(type) || isLiteralTypeNode(type)) {
+    return type;
+  }
+
+  if (isTypeReferenceNode(type)) {
+    const typeName = isIdentifier(type.typeName)
+      ? type.typeName.escapedText.toString()
+      : undefined;
+
+    if (typeName === "Map") {
+      return factory.createTypeReferenceNode(
+        factory.createIdentifier("ReadonlyMap"),
+        type.typeArguments
+      );
+    }
+
+    if (typeName === "Set") {
+      return factory.createTypeReferenceNode(
+        factory.createIdentifier("ReadonlySet"),
+        type.typeArguments
+      );
+    }
+
+    if (typeName === "Date" || typeName === "Promise") {
+      return type;
+    }
+  }
+
+  return factory.createTypeReferenceNode(factory.createIdentifier("Readonly"), [
+    type,
+  ]);
+}
+
+function isReadonlyPrimitiveType(type: TypeNode): boolean {
+  return [
+    SyntaxKind.AnyKeyword,
+    SyntaxKind.BigIntKeyword,
+    SyntaxKind.BooleanKeyword,
+    SyntaxKind.NeverKeyword,
+    SyntaxKind.NumberKeyword,
+    SyntaxKind.StringKeyword,
+    SyntaxKind.SymbolKeyword,
+    SyntaxKind.UndefinedKeyword,
+    SyntaxKind.UnknownKeyword,
+    SyntaxKind.VoidKeyword,
+  ].includes(type.kind);
+}
+
+const RESERVED_IDENTIFIER_NAMES = new Set([
+  "abstract",
+  "accessor",
+  "any",
+  "as",
+  "asserts",
+  "async",
+  "await",
+  "bigint",
+  "boolean",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "constructor",
+  "continue",
+  "debugger",
+  "declare",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "from",
+  "function",
+  "get",
+  "global",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "infer",
+  "instanceof",
+  "interface",
+  "intrinsic",
+  "is",
+  "keyof",
+  "let",
+  "module",
+  "namespace",
+  "never",
+  "new",
+  "null",
+  "number",
+  "object",
+  "of",
+  "out",
+  "override",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "readonly",
+  "require",
+  "return",
+  "satisfies",
+  "set",
+  "static",
+  "string",
+  "super",
+  "switch",
+  "symbol",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "type",
+  "typeof",
+  "undefined",
+  "unique",
+  "unknown",
+  "using",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
 function createTsAstPropertyKey(key: string): Identifier | StringLiteral {
-  // TODO: is TsTypeNode correct or required anymore?
-  if (/^[$A-Z_a-z][\w$]*$/.test(key)) {
+  if (isSafePropertyIdentifier(key)) {
     return factory.createIdentifier(key);
   }
   return factory.createStringLiteral(key);
+}
+
+function isSafePropertyIdentifier(key: string): boolean {
+  return isIdentifierName(key) && !RESERVED_IDENTIFIER_NAMES.has(key);
+}
+
+function isIdentifierName(value: string): boolean {
+  const [firstCharacter] = value;
+
+  if (!firstCharacter) {
+    return false;
+  }
+
+  return (
+    isIdentifierStart(firstCharacter.codePointAt(0)!, ScriptTarget.Latest) &&
+    Array.from(value.slice(firstCharacter.length)).every(character =>
+      isIdentifierPart(character.codePointAt(0)!, ScriptTarget.Latest)
+    )
+  );
 }


### PR DESCRIPTION
## Summary

Expand Zod-to-TypeScript generation so supported Zod v4 wrapper schemas emit concrete TypeScript types instead of falling back to `unknown`. This improves generated type fidelity for common schema composition patterns while keeping unsupported advanced schemas safely mapped to `unknown`.

## Changes

- Add generation support for `z.nonoptional()`, `z.readonly()`, `z.catch()`, `z.pipe()`, `z.nan()`, `z.file()`, and `z.success()`.
- Generate `z.pipe()` from the output schema, with unsupported outputs still falling back to `unknown`.
- Quote reserved and unsafe object property keys so emitted type literals stay valid.
- Preserve existing behavior for literals, bigint literals, enum values, tuple rest, and specialized literal errors.
- Update the `@rexeus/typeweaver-zod-to-ts` README support matrix and add a minor changeset.
- Expand unit coverage for wrapper edge cases, readonly variants, pipe output optionality, catch/default behavior, and unsafe property keys.

## Test Plan

- `pnpm --filter @rexeus/typeweaver-zod-to-ts test`
- `pnpm --filter @rexeus/typeweaver-zod-to-ts typecheck`
- `pnpm --filter @rexeus/typeweaver-zod-to-ts build`