### PR TITLE
fix(ci): stabilize architecture contract gate

### DIFF
--- a/.changeset/effect-runtime-migration.md
+++ b/.changeset/effect-runtime-migration.md
@@ -65,7 +65,8 @@ unchanged — existing specs keep working byte-for-byte.
   `@rexeus/typeweaver-gen` wraps it at the normalization boundary into a tagged
   `DuplicateResponseNameError`, so the `NormalizationError` union is fully `catchTag`-addressable.
 
-Breaking changes are documented in [MIGRATION.md](../MIGRATION.md#migrating-from-012x-to-10x).
+Breaking changes are documented in the
+[migration guide](https://github.com/rexeus/typeweaver/blob/main/MIGRATION.md#migrating-from-012x-to-10x).
 Background on the design decisions:
 
 - ADR 0003 — Effect-native plugin API (V2)

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -105,12 +105,15 @@ jobs:
           pnpm run typecheck
           echo "::endgroup::"
 
-      - name: Verify Effect migration
+      # Durable post-migration gate: package-manager portability, the pinned
+      # Effect baseline, public contracts, generated output, workspace tests,
+      # and packed-consumer compatibility.
+      - name: Verify architecture contracts
         env:
           NODE_OPTIONS: "--max-old-space-size=6144"
         run: |
-          echo "::group::Effect migration contract"
-          pnpm run verify:effect-migration
+          echo "::group::Architecture contracts"
+          pnpm run verify:architecture-contracts
           echo "::endgroup::"
 
       - name: Check formatting

--- a/GOAL.md
+++ b/GOAL.md
@@ -152,7 +152,7 @@ pnpm install --frozen-lockfile
 pnpm test:gen
 pnpm --filter @rexeus/typeweaver test:bundle:all
 pnpm typecheck
-pnpm verify:effect-migration
+pnpm verify:architecture-contracts
 pnpm docs:check
 pnpm format:check
 pnpm lint

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "verify:generated": "node scripts/verify-generated.mjs",
     "verify:effect-reference": "node scripts/verify-effect-reference.mjs && node scripts/test-effect-reference-guard.mjs",
     "effect:diagnostics": "node scripts/test-effect-diagnostics.mjs && node scripts/run-effect-diagnostics.mjs",
-    "docs:check": "node scripts/test-effect-version-contract.mjs && node scripts/check-effect-version-contract.mjs && node scripts/check-markdown-links.mjs",
+    "verify:effect-version": "node scripts/test-effect-version-contract.mjs && node scripts/check-effect-version-contract.mjs",
+    "docs:check": "node scripts/check-markdown-links.mjs",
     "verify:packed-consumers": "node scripts/test-packed-consumers.mjs",
-    "verify:effect-migration": "node scripts/verify-effect-migration.mjs",
+    "test:pnpm-launcher": "node scripts/test-pnpm-launcher.mjs",
+    "verify:architecture-contracts": "node scripts/verify-architecture-contracts.mjs",
     "publish:dry": "pnpm publish -r --dry-run --no-git-checks",
     "ci:publish": "pnpm publish -r --provenance",
     "prepare:commit": "pnpm run format && pnpm run lint:fix && pnpm run typecheck && pnpm run build && pnpm run test"

--- a/packages/cli/__test__/cli.process.test.ts
+++ b/packages/cli/__test__/cli.process.test.ts
@@ -13,6 +13,18 @@ type ProcessResult = {
 
 const packageDirectory = path.resolve(import.meta.dirname, "..");
 const cliEntry = path.join(packageDirectory, "bin", "typeweaver.mjs");
+const packageManifest: unknown = JSON.parse(
+  fs.readFileSync(path.join(packageDirectory, "package.json"), "utf8")
+);
+if (
+  typeof packageManifest !== "object" ||
+  packageManifest === null ||
+  !("version" in packageManifest) ||
+  typeof packageManifest.version !== "string"
+) {
+  throw new Error("CLI package.json must declare a string version");
+}
+const packageVersion = packageManifest.version;
 const processOutputsDirectory = path.join(
   packageDirectory,
   "test",
@@ -531,12 +543,12 @@ describe("built CLI flag and verbosity handling", () => {
     expect(result.stdout).toContain("[DEBUG] Released output lock");
   });
 
-  test("preserves Commander's historical -V version alias", async () => {
+  test("reports the package version through Commander's historical -V alias", async () => {
     const workspace = createWorkspace();
     const result = await runCli(workspace, ["-V"]);
 
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toBe("Running on Node.js\n0.12.0\n\n");
+    expect(result.stdout).toBe(`Running on Node.js\n${packageVersion}\n\n`);
     expect(result.stdout).not.toContain("[DEBUG]");
   });
 });

--- a/plans/001-product-truth-and-type-safety.md
+++ b/plans/001-product-truth-and-type-safety.md
@@ -46,7 +46,9 @@ implementing.
 - ADR 0001 and ADR 0002 remain `Proposed` although their architecture is implemented. ADR 0001
   contains the obsolete bare-array `defineSpec` resource example tracked by #198 and #200.
 - `scripts/check-markdown-links.mjs` verifies local file targets but does not compile code blocks.
-  `docs:check` checks links and the Effect version contract.
+  `docs:check` checks Markdown links, `verify:effect-version` enforces the Effect dependency and
+  version contracts, and `verify:architecture-contracts` composes both checks into the durable
+  architecture gate.
 - `packages/cli/examples/tsconfig.json` proves that checked-in TypeScript examples can be
   typechecked as part of a package command. Use this as the executable-docs pattern.
 - `packages/zod-to-ts/src/tsTypeGenerator.ts` intentionally maps `z.unknown()` to TypeScript

--- a/plans/README.md
+++ b/plans/README.md
@@ -62,7 +62,7 @@ pnpm install --frozen-lockfile
 pnpm test:gen
 pnpm --filter @rexeus/typeweaver test:bundle:all
 pnpm typecheck
-pnpm verify:effect-migration
+pnpm verify:architecture-contracts
 pnpm docs:check
 pnpm format:check
 pnpm lint

--- a/scripts/lib/pnpm-command.mjs
+++ b/scripts/lib/pnpm-command.mjs
@@ -32,7 +32,10 @@ export const resolvePnpmInvocation = ({
 };
 
 export const spawnPnpmSync = ({ args, ...options }) => {
-  const invocation = resolvePnpmInvocation({ args });
+  const invocation = resolvePnpmInvocation({
+    args,
+    npmExecPath: options.env?.npm_execpath ?? process.env.npm_execpath,
+  });
   return spawnSync(invocation.command, invocation.args, {
     ...options,
     shell: invocation.shell,

--- a/scripts/lib/pnpm-command.mjs
+++ b/scripts/lib/pnpm-command.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+const nodeScriptExtensions = new Set([".cjs", ".js", ".mjs"]);
+const windowsShellExtensions = new Set([".bat", ".cmd"]);
+
+export const resolvePnpmInvocation = ({
+  args,
+  npmExecPath = process.env.npm_execpath,
+  nodeExecPath = process.execPath,
+  platform = process.platform,
+}) => {
+  if (npmExecPath === undefined || npmExecPath === "") {
+    throw new Error("Run this command through pnpm.");
+  }
+
+  const extension = path.extname(npmExecPath).toLowerCase();
+  if (nodeScriptExtensions.has(extension)) {
+    return {
+      args: [npmExecPath, ...args],
+      command: nodeExecPath,
+      shell: false,
+    };
+  }
+
+  return {
+    args,
+    command: npmExecPath,
+    shell: platform === "win32" && windowsShellExtensions.has(extension),
+  };
+};
+
+export const spawnPnpmSync = ({ args, ...options }) => {
+  const invocation = resolvePnpmInvocation({ args });
+  return spawnSync(invocation.command, invocation.args, {
+    ...options,
+    shell: invocation.shell,
+  });
+};

--- a/scripts/test-maintainability-lint.mjs
+++ b/scripts/test-maintainability-lint.mjs
@@ -11,16 +11,12 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import { spawnPnpmSync } from "./lib/pnpm-command.mjs";
 
 const workspaceRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
-const pnpmCli = process.env.npm_execpath;
-if (pnpmCli === undefined) {
-  throw new Error("Run this check through `pnpm test:maintainability-lint`.");
-}
-
 const switchComplexity = caseCount =>
   [
     "function switchComplexity(value) {",
@@ -470,15 +466,12 @@ const parseLintOutput = result => {
 };
 
 const runRootLint = () => {
-  const result = spawnSync(
-    process.execPath,
-    [pnpmCli, "--silent", "run", "lint", "--format=json"],
-    {
-      cwd: workspaceRoot,
-      encoding: "utf8",
-      maxBuffer: 50 * 1024 * 1024,
-    }
-  );
+  const result = spawnPnpmSync({
+    args: ["--silent", "run", "lint", "--format=json"],
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
   return { ...parseLintOutput(result), status: result.status };
 };
 

--- a/scripts/test-packed-consumers.mjs
+++ b/scripts/test-packed-consumers.mjs
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { spawnPnpmSync } from "./lib/pnpm-command.mjs";
 
 const workspaceRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -27,8 +28,6 @@ const contract = JSON.parse(
 const rootPackage = JSON.parse(
   readFileSync(path.join(workspaceRoot, "package.json"), "utf8")
 );
-const pnpmCli = process.env.npm_execpath;
-assert(pnpmCli, "run this verification through pnpm");
 const archiveName = ({ name, version }) =>
   `${name.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`;
 const readJson = filePath => JSON.parse(readFileSync(filePath, "utf8"));
@@ -36,7 +35,8 @@ const writeJson = (filePath, value) =>
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 
 const run = ({ args, cwd }) => {
-  const result = spawnSync(process.execPath, [pnpmCli, ...args], {
+  const result = spawnPnpmSync({
+    args,
     cwd,
     encoding: "utf8",
     env: process.env,

--- a/scripts/test-pnpm-launcher.mjs
+++ b/scripts/test-pnpm-launcher.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import process from "node:process";
+import { resolvePnpmInvocation, spawnPnpmSync } from "./lib/pnpm-command.mjs";
+
+// pnpm/action-setup may expose npm_execpath as JavaScript, a native binary,
+// or a Windows command shim. Keep every supported launcher shape explicit.
+
+assert.throws(
+  () =>
+    resolvePnpmInvocation({
+      args: ["--version"],
+      npmExecPath: "",
+    }),
+  /Run this command through pnpm/
+);
+
+assert.deepEqual(
+  resolvePnpmInvocation({
+    args: ["run", "lint"],
+    nodeExecPath: "/runtime/node",
+    npmExecPath: "/tools/pnpm.cjs",
+    platform: "linux",
+  }),
+  {
+    args: ["/tools/pnpm.cjs", "run", "lint"],
+    command: "/runtime/node",
+    shell: false,
+  }
+);
+
+assert.deepEqual(
+  resolvePnpmInvocation({
+    args: ["run", "lint"],
+    nodeExecPath: "/runtime/node",
+    npmExecPath: "/tools/pnpm",
+    platform: "linux",
+  }),
+  {
+    args: ["run", "lint"],
+    command: "/tools/pnpm",
+    shell: false,
+  }
+);
+
+assert.deepEqual(
+  resolvePnpmInvocation({
+    args: ["run", "lint"],
+    nodeExecPath: "C:\\runtime\\node.exe",
+    npmExecPath: "C:\\tools\\pnpm.cmd",
+    platform: "win32",
+  }),
+  {
+    args: ["run", "lint"],
+    command: "C:\\tools\\pnpm.cmd",
+    shell: true,
+  }
+);
+
+const activePnpm = spawnPnpmSync({
+  args: ["--version"],
+  encoding: "utf8",
+  env: process.env,
+});
+assert.equal(activePnpm.status, 0, activePnpm.stderr);
+assert.match(activePnpm.stdout.trim(), /^\d+\.\d+\.\d+$/u);
+
+process.stdout.write(
+  "pnpm launcher verified for JavaScript, native, and Windows command entrypoints\n"
+);

--- a/scripts/test-pnpm-launcher.mjs
+++ b/scripts/test-pnpm-launcher.mjs
@@ -56,6 +56,21 @@ assert.deepEqual(
   }
 );
 
+const environmentSelectedLauncher = spawnPnpmSync({
+  args: ["--version"],
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    npm_execpath: process.execPath,
+  },
+});
+assert.equal(
+  environmentSelectedLauncher.status,
+  0,
+  environmentSelectedLauncher.stderr
+);
+assert.equal(environmentSelectedLauncher.stdout.trim(), process.version);
+
 const activePnpm = spawnPnpmSync({
   args: ["--version"],
   encoding: "utf8",

--- a/scripts/verify-architecture-contracts.mjs
+++ b/scripts/verify-architecture-contracts.mjs
@@ -1,19 +1,15 @@
-import { spawnSync, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { lstatSync, readFileSync, readlinkSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { spawnPnpmSync } from "./lib/pnpm-command.mjs";
 
 const workspaceRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
-const pnpmCli = process.env.npm_execpath;
-if (pnpmCli === undefined) {
-  throw new Error("Run this gate through `pnpm verify:effect-migration`.");
-}
-
 const hash = value => createHash("sha256").update(value).digest("hex");
 
 const gitOutput = args =>
@@ -51,11 +47,19 @@ const snapshotAuthoredWorktree = () => ({
 
 const commands = [
   {
-    label: "Effect source reference",
+    label: "Package-manager launcher contract",
+    args: ["run", "test:pnpm-launcher"],
+  },
+  {
+    label: "Pinned Effect source contract",
     args: ["run", "verify:effect-reference"],
   },
   {
-    label: "Effect version and documentation contracts",
+    label: "Effect dependency and version contracts",
+    args: ["run", "verify:effect-version"],
+  },
+  {
+    label: "Documentation link integrity",
     args: ["run", "docs:check"],
   },
   {
@@ -67,7 +71,7 @@ const commands = [
     args: ["run", "effect:diagnostics"],
   },
   {
-    label: "Migration type contracts",
+    label: "Public CLI type contracts",
     args: ["--filter", "@rexeus/typeweaver", "run", "typecheck:contracts"],
   },
   {
@@ -102,7 +106,8 @@ const commands = [
 
 const runPnpm = ({ label, args }) => {
   process.stdout.write(`\n==> ${label}\n`);
-  const result = spawnSync(process.execPath, [pnpmCli, ...args], {
+  const result = spawnPnpmSync({
+    args,
     cwd: workspaceRoot,
     env: process.env,
     stdio: "inherit",
@@ -128,7 +133,7 @@ try {
 const after = snapshotAuthoredWorktree();
 if (JSON.stringify(after) !== JSON.stringify(before)) {
   throw new Error(
-    "verify:effect-migration changed the authored Git worktree",
+    "verify:architecture-contracts changed the authored Git worktree",
     commandFailure === undefined ? undefined : { cause: commandFailure }
   );
 }
@@ -137,5 +142,5 @@ if (commandFailure !== undefined) {
 }
 
 process.stdout.write(
-  "\nEffect migration verification passed without changing the authored worktree\n"
+  "\nArchitecture contracts passed without changing the authored worktree\n"
 );


### PR DESCRIPTION
## Summary

Make the post-Effect CI gate durable across release versioning and pnpm launcher changes. This fixes the failures visible in release PR #205 and prepares the gate for pnpm/action-setup v6 in Dependabot PR #203.

## Why

The gate was still named after the completed migration and grouped unrelated contracts under one label. Changesets moved a relative migration link into package changelogs, the CLI process test pinned version 0.12.0, and nested scripts assumed npm_execpath was always JavaScript. pnpm/action-setup v6 exposes a directly executable launcher instead.

## Changes

- Rename the umbrella command and workflow step to `verify:architecture-contracts`.
- Split Effect version checks from documentation link integrity and label each sub-contract.
- Add a tested pnpm launcher that handles JavaScript entrypoints, native executables, and Windows command shims, and reuse it in every nested pnpm caller.
- Use a release-stable migration-guide URL in the Changeset.
- Derive the CLI `-V` expectation from the package manifest.

## How to test

1. Run `pnpm run verify:architecture-contracts`.
2. Run `pnpm run --filter @rexeus/typeweaver test:bundle:all`.
3. Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, and `pnpm run build`.
4. Run `actionlint .github/workflows/quality-check.yml`.

Expected: all commands pass without modifying the authored worktree. A Changesets version simulation at 1.0.0 should produce ten valid changelog links, and the CLI `-V` process test should report 1.0.0.

## Review focus

Please review the launcher selection in `scripts/lib/pnpm-command.mjs` first, then the renamed orchestration in `scripts/verify-architecture-contracts.mjs`, and finally the two release-specific regressions.

## Notes

- No package API or runtime behavior changes.
- This branch includes the current `main` state from PR #207.
- PR #203 can be rebased after this lands to exercise pnpm/action-setup v6 against the corrected launcher contract.