### PR TITLE
fix(release): keep Effect migration on 0.13

### DIFF
--- a/.changeset/effect-runtime-migration.md
+++ b/.changeset/effect-runtime-migration.md
@@ -1,14 +1,14 @@
 ---
-"@rexeus/typeweaver": major
-"@rexeus/typeweaver-core": major
-"@rexeus/typeweaver-gen": major
-"@rexeus/typeweaver-types": major
-"@rexeus/typeweaver-clients": major
-"@rexeus/typeweaver-aws-cdk": major
-"@rexeus/typeweaver-hono": major
-"@rexeus/typeweaver-server": major
-"@rexeus/typeweaver-openapi": major
-"@rexeus/typeweaver-zod-to-ts": major
+"@rexeus/typeweaver": minor
+"@rexeus/typeweaver-core": minor
+"@rexeus/typeweaver-gen": minor
+"@rexeus/typeweaver-types": minor
+"@rexeus/typeweaver-clients": minor
+"@rexeus/typeweaver-aws-cdk": minor
+"@rexeus/typeweaver-hono": minor
+"@rexeus/typeweaver-server": minor
+"@rexeus/typeweaver-openapi": minor
+"@rexeus/typeweaver-zod-to-ts": minor
 ---
 
 Migrate the runtime, plugin API, and CLI to Effect.
@@ -66,7 +66,7 @@ unchanged — existing specs keep working byte-for-byte.
   `DuplicateResponseNameError`, so the `NormalizationError` union is fully `catchTag`-addressable.
 
 Breaking changes are documented in the
-[migration guide](https://github.com/rexeus/typeweaver/blob/main/MIGRATION.md#migrating-from-012x-to-10x).
+[migration guide](https://github.com/rexeus/typeweaver/blob/main/MIGRATION.md#migrating-from-012x-to-013x).
 Background on the design decisions:
 
 - ADR 0003 — Effect-native plugin API (V2)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,21 +1,21 @@
 # TypeWeaver Migration Guide
 
-This document covers all breaking changes and required migration steps across major TypeWeaver
-releases.
+This document covers all breaking changes and required migration steps across TypeWeaver release
+lines.
 
 ---
 
 ## Table of Contents
 
-- [Migrating from 0.12.x to 1.0.x](#migrating-from-012x-to-10x)
+- [Migrating from 0.12.x to 0.13.x](#migrating-from-012x-to-013x)
 - [Migrating from 0.7.x to 0.8.x](#migrating-from-07x-to-08x)
 - [Migrating from 0.8.x to 0.9.x](#migrating-from-08x-to-09x)
 
 ---
 
-## Migrating from 0.12.x to 1.0.x
+## Migrating from 0.12.x to 0.13.x
 
-Version 1.0.0 completes the migration to **Effect** as typeweaver's runtime foundation. The change
+Version 0.13.0 completes the migration to **Effect** as typeweaver's runtime foundation. The change
 is internal-architectural but breaks three surfaces:
 
 1. The **plugin API** (V1 class-based → V2 Effect-native records). Affects anyone who built a custom
@@ -58,7 +58,7 @@ export class TypesPlugin extends BasePlugin {
 }
 ```
 
-**After (1.0.x) — V2 plugin:**
+**After (0.13.x) — V2 plugin:**
 
 ```ts
 import path from "node:path";
@@ -84,7 +84,7 @@ TypeWeaver itself develops and tests against Effect 3.22.0:
 ```json
 {
   "peerDependencies": {
-    "@rexeus/typeweaver-gen": "^1.0.0",
+    "@rexeus/typeweaver-gen": "^0.13.0",
     "effect": ">=3.22.0 <4"
   }
 }
@@ -200,7 +200,7 @@ If you imported the generator programmatically rather than through the CLI:
 
 ### 4. Spec authoring API: UNCHANGED
 
-The functional spec API introduced in 0.9.0 is unchanged in 1.0.0:
+The functional spec API introduced in 0.9.0 is unchanged in 0.13.0:
 
 - `defineSpec({ resources: { ... } })`
 - `defineOperation({ ... })`
@@ -210,9 +210,9 @@ The functional spec API introduced in 0.9.0 is unchanged in 1.0.0:
 Zod schemas continue to be authored the same way. Regeneration updates the generated client, server,
 and Hono support code to the options-object APIs described above, so expect source diffs. The
 generated request, response, validation, and runtime behavior remain compatible. The
-`test-utils/src/test-project/output` golden fixture verifies the exact 1.0 output on every build.
+`test-utils/src/test-project/output` golden fixture verifies the exact 0.13 output on every build.
 
-### 5. Migration Checklist (0.12.x to 1.0.x)
+### 5. Migration Checklist (0.12.x to 0.13.x)
 
 For **end users** (you use the CLI but don't author plugins):
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,7 +15,7 @@ lines.
 
 ## Migrating from 0.12.x to 0.13.x
 
-Version 0.13.0 completes the migration to **Effect** as typeweaver's runtime foundation. The change
+Version 0.13.0 completes the migration to **Effect** as TypeWeaver's runtime foundation. The change
 is internal-architectural but breaks three surfaces:
 
 1. The **plugin API** (V1 class-based → V2 Effect-native records). Affects anyone who built a custom

--- a/config/release-policy.json
+++ b/config/release-policy.json
@@ -1,0 +1,4 @@
+{
+  "maximumPublishedMajor": 0,
+  "breakingChangeBump": "minor"
+}

--- a/docs/adr/0009-pre-1-release-version-policy.md
+++ b/docs/adr/0009-pre-1-release-version-policy.md
@@ -1,0 +1,38 @@
+# ADR 0009: Pre-1.0 Release Version Policy
+
+## Status
+
+Accepted
+
+## Context
+
+TypeWeaver remains an early-stage project working toward a deliberate stable 1.0 release. The Effect
+migration contains breaking public changes, but it does not mark that stability milestone. The next
+coordinated package release after `0.12.0` is therefore `0.13.0`.
+
+The repository patches `@changesets/assemble-release-plan` to prevent peer-dependency propagation
+from automatically promoting dependents to a major release. That patch intentionally does not
+override a `major` release written directly into Changesets frontmatter. An explicit `major` entry
+therefore still produces `1.0.0`.
+
+## Decision
+
+1. Published `@rexeus/*` packages remain on major version `0` until an explicit stability decision
+   changes `config/release-policy.json`.
+2. Breaking changes during this period use a Changesets `minor` bump. From `0.12.0`, the Effect
+   migration therefore releases as `0.13.0`.
+3. The existing Changesets patch remains responsible only for suppressing false major bumps caused
+   by peer-dependency propagation.
+4. `pnpm verify:release-version` rejects both:
+   - pending explicit `major` Changesets while the configured release line is `0.x`; and
+   - generated package manifests whose version exceeds the configured major.
+5. `pnpm verify:architecture-contracts` runs the release-version contract on normal pull requests
+   and generated Changesets release pull requests.
+
+## Consequences
+
+- A breaking pre-1.0 release remains visible as a minor version change.
+- An accidental `1.0.0` plan fails before merge, even if it originated outside peer-dependency
+  propagation.
+- Releasing 1.0 requires an intentional policy change, migration review, and corresponding
+  documentation update rather than a lone Changeset entry.

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -392,7 +392,7 @@ plugins:
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "peerDependencies": {
-    "@rexeus/typeweaver-gen": "^1.0.0",
+    "@rexeus/typeweaver-gen": "^0.13.0",
     "effect": ">=3.22.0 <4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "verify:effect-reference": "node scripts/verify-effect-reference.mjs && node scripts/test-effect-reference-guard.mjs",
     "effect:diagnostics": "node scripts/test-effect-diagnostics.mjs && node scripts/run-effect-diagnostics.mjs",
     "verify:effect-version": "node scripts/test-effect-version-contract.mjs && node scripts/check-effect-version-contract.mjs",
+    "verify:release-version": "node scripts/test-release-version-contract.mjs && node scripts/check-release-version-contract.mjs",
     "docs:check": "node scripts/check-markdown-links.mjs",
     "verify:packed-consumers": "node scripts/test-packed-consumers.mjs",
     "test:pnpm-launcher": "node scripts/test-pnpm-launcher.mjs",

--- a/scripts/check-release-version-contract.mjs
+++ b/scripts/check-release-version-contract.mjs
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  parseChangesetReleases,
+  validateReleaseVersionContract,
+} from "./lib/release-version-contract.mjs";
+
+const workspaceRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const read = relativePath =>
+  readFileSync(path.join(workspaceRoot, relativePath), "utf8");
+const readJson = relativePath => JSON.parse(read(relativePath));
+const policy = readJson("config/release-policy.json");
+
+const packages = readdirSync(path.join(workspaceRoot, "packages"), {
+  withFileTypes: true,
+}).flatMap(entry => {
+  if (!entry.isDirectory()) {
+    return [];
+  }
+  const manifestPath = `packages/${entry.name}/package.json`;
+  if (!existsSync(path.join(workspaceRoot, manifestPath))) {
+    return [];
+  }
+  const manifest = readJson(manifestPath);
+  return typeof manifest.name === "string" &&
+    manifest.name.startsWith("@rexeus/") &&
+    typeof manifest.version === "string"
+    ? [
+        {
+          name: manifest.name,
+          version: manifest.version,
+        },
+      ]
+    : [];
+});
+
+const changesets = readdirSync(path.join(workspaceRoot, ".changeset"), {
+  withFileTypes: true,
+})
+  .filter(entry => entry.isFile() && entry.name.endsWith(".md"))
+  .map(entry => ({
+    fileName: `.changeset/${entry.name}`,
+    releases: parseChangesetReleases({
+      fileName: `.changeset/${entry.name}`,
+      content: read(`.changeset/${entry.name}`),
+    }),
+  }));
+
+const failures = validateReleaseVersionContract({
+  maximumPublishedMajor: policy.maximumPublishedMajor,
+  packages,
+  changesets,
+});
+
+if (policy.breakingChangeBump !== "minor") {
+  failures.push(
+    "breakingChangeBump must remain minor while TypeWeaver follows a pre-1.0 release line"
+  );
+}
+
+if (failures.length > 0) {
+  process.stderr.write(`${failures.join("\n")}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(
+  `Release version contract verified: ${String(packages.length)} packages remain on major ${String(policy.maximumPublishedMajor)}\n`
+);

--- a/scripts/check-release-version-contract.mjs
+++ b/scripts/check-release-version-contract.mjs
@@ -4,6 +4,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import {
   parseChangesetReleases,
+  validateReleasePolicy,
   validateReleaseVersionContract,
 } from "./lib/release-version-contract.mjs";
 
@@ -57,11 +58,7 @@ const failures = validateReleaseVersionContract({
   changesets,
 });
 
-if (policy.breakingChangeBump !== "minor") {
-  failures.push(
-    "breakingChangeBump must remain minor while TypeWeaver follows a pre-1.0 release line"
-  );
-}
+failures.push(...validateReleasePolicy(policy));
 
 if (failures.length > 0) {
   process.stderr.write(`${failures.join("\n")}\n`);

--- a/scripts/lib/release-version-contract.mjs
+++ b/scripts/lib/release-version-contract.mjs
@@ -1,0 +1,107 @@
+const semanticVersionPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+].*)?$/u;
+const changesetFrontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u;
+const releaseLinePattern =
+  /^\s*(?:"([^"]+)"|'([^']+)'|([^:\s]+))\s*:\s*(patch|minor|major)\s*$/u;
+
+const parseMajor = version => {
+  const match = semanticVersionPattern.exec(version);
+  return match === null ? undefined : Number(match[1]);
+};
+
+const registerPackageMajor = ({
+  packageManifest,
+  packageMajors,
+  maximumPublishedMajor,
+}) => {
+  const major = parseMajor(packageManifest.version);
+  if (major === undefined) {
+    return [
+      `${packageManifest.name} has an invalid semantic version: ${packageManifest.version}`,
+    ];
+  }
+  if (packageMajors.has(packageManifest.name)) {
+    return [`duplicate package manifest: ${packageManifest.name}`];
+  }
+
+  packageMajors.set(packageManifest.name, major);
+  return major > maximumPublishedMajor
+    ? [
+        `${packageManifest.name}@${packageManifest.version} exceeds the configured release line ${String(maximumPublishedMajor)}.x`,
+      ]
+    : [];
+};
+
+const validateChangeset = ({
+  changeset,
+  packageMajors,
+  maximumPublishedMajor,
+}) =>
+  changeset.releases.flatMap(release => {
+    const currentMajor = packageMajors.get(release.name);
+    return release.type === "major" &&
+      currentMajor !== undefined &&
+      currentMajor + 1 > maximumPublishedMajor
+      ? [
+          `${changeset.fileName} requests a major release for ${release.name}; use a minor changeset while the release line is capped at ${String(maximumPublishedMajor)}.x`,
+        ]
+      : [];
+  });
+
+export const parseChangesetReleases = ({ fileName, content }) => {
+  const frontmatter = changesetFrontmatterPattern.exec(content);
+  if (frontmatter === null) {
+    throw new Error(`${fileName} does not contain Changesets frontmatter`);
+  }
+
+  return frontmatter[1]
+    .split(/\r?\n/u)
+    .filter(line => line.trim() !== "")
+    .map(line => {
+      const release = releaseLinePattern.exec(line);
+      if (release === null) {
+        throw new Error(
+          `${fileName} contains an invalid release entry: ${line}`
+        );
+      }
+      return {
+        name: release[1] ?? release[2] ?? release[3],
+        type: release[4],
+      };
+    });
+};
+
+export const validateReleaseVersionContract = ({
+  maximumPublishedMajor,
+  packages,
+  changesets,
+}) => {
+  const failures = [];
+  const packageMajors = new Map();
+
+  if (!Number.isInteger(maximumPublishedMajor) || maximumPublishedMajor < 0) {
+    return ["maximumPublishedMajor must be a non-negative integer"];
+  }
+
+  for (const packageManifest of packages) {
+    failures.push(
+      ...registerPackageMajor({
+        packageManifest,
+        packageMajors,
+        maximumPublishedMajor,
+      })
+    );
+  }
+
+  for (const changeset of changesets) {
+    failures.push(
+      ...validateChangeset({
+        changeset,
+        packageMajors,
+        maximumPublishedMajor,
+      })
+    );
+  }
+
+  return failures;
+};

--- a/scripts/lib/release-version-contract.mjs
+++ b/scripts/lib/release-version-contract.mjs
@@ -39,14 +39,27 @@ const validateChangeset = ({
 }) =>
   changeset.releases.flatMap(release => {
     const currentMajor = packageMajors.get(release.name);
-    return release.type === "major" &&
-      currentMajor !== undefined &&
-      currentMajor + 1 > maximumPublishedMajor
+    if (currentMajor === undefined) {
+      return [
+        `${changeset.fileName} references unknown package ${release.name}`,
+      ];
+    }
+    return release.type === "major" && currentMajor + 1 > maximumPublishedMajor
       ? [
           `${changeset.fileName} requests a major release for ${release.name}; use a minor changeset while the release line is capped at ${String(maximumPublishedMajor)}.x`,
         ]
       : [];
   });
+
+export const validateReleasePolicy = ({
+  maximumPublishedMajor,
+  breakingChangeBump,
+}) =>
+  maximumPublishedMajor === 0 && breakingChangeBump !== "minor"
+    ? [
+        "breakingChangeBump must remain minor while TypeWeaver follows a pre-1.0 release line",
+      ]
+    : [];
 
 export const parseChangesetReleases = ({ fileName, content }) => {
   const frontmatter = changesetFrontmatterPattern.exec(content);

--- a/scripts/lib/release-version-contract.mjs
+++ b/scripts/lib/release-version-contract.mjs
@@ -1,5 +1,5 @@
 const semanticVersionPattern =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+].*)?$/u;
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
 const changesetFrontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u;
 const releaseLinePattern =
   /^\s*(?:"([^"]+)"|'([^']+)'|([^:\s]+))\s*:\s*(patch|minor|major)\s*$/u;

--- a/scripts/test-release-version-contract.mjs
+++ b/scripts/test-release-version-contract.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   parseChangesetReleases,
+  validateReleasePolicy,
   validateReleaseVersionContract,
 } from "./lib/release-version-contract.mjs";
 
@@ -10,12 +11,12 @@ const packages = [
     version: "0.12.0",
   },
 ];
-const changeset = type => ({
+const changeset = (type, name = "@rexeus/typeweaver") => ({
   fileName: "fixture.md",
   releases: parseChangesetReleases({
     fileName: "fixture.md",
     content: `---
-"@rexeus/typeweaver": ${type}
+"${name}": ${type}
 ---
 
 Fixture release.
@@ -53,6 +54,15 @@ assert.match(
 );
 
 assert.match(
+  validateReleaseVersionContract({
+    maximumPublishedMajor: 0,
+    packages,
+    changesets: [changeset("major", "@rexeus/missing")],
+  }).join("\n"),
+  /references unknown package @rexeus\/missing/u
+);
+
+assert.match(
   validatePackageVersion("1.0.0").join("\n"),
   /exceeds the configured release line 0\.x/u
 );
@@ -79,6 +89,22 @@ assert.deepEqual(
     maximumPublishedMajor: 1,
     packages,
     changesets: [changeset("major")],
+  }),
+  []
+);
+
+assert.match(
+  validateReleasePolicy({
+    maximumPublishedMajor: 0,
+    breakingChangeBump: "major",
+  }).join("\n"),
+  /must remain minor/u
+);
+
+assert.deepEqual(
+  validateReleasePolicy({
+    maximumPublishedMajor: 1,
+    breakingChangeBump: "major",
   }),
   []
 );

--- a/scripts/test-release-version-contract.mjs
+++ b/scripts/test-release-version-contract.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import {
+  parseChangesetReleases,
+  validateReleaseVersionContract,
+} from "./lib/release-version-contract.mjs";
+
+const packages = [
+  {
+    name: "@rexeus/typeweaver",
+    version: "0.12.0",
+  },
+];
+const changeset = type => ({
+  fileName: "fixture.md",
+  releases: parseChangesetReleases({
+    fileName: "fixture.md",
+    content: `---
+"@rexeus/typeweaver": ${type}
+---
+
+Fixture release.
+`,
+  }),
+});
+
+assert.deepEqual(
+  validateReleaseVersionContract({
+    maximumPublishedMajor: 0,
+    packages,
+    changesets: [changeset("minor")],
+  }),
+  []
+);
+
+assert.match(
+  validateReleaseVersionContract({
+    maximumPublishedMajor: 0,
+    packages,
+    changesets: [changeset("major")],
+  }).join("\n"),
+  /requests a major release/u
+);
+
+assert.match(
+  validateReleaseVersionContract({
+    maximumPublishedMajor: 0,
+    packages: [
+      {
+        name: "@rexeus/typeweaver",
+        version: "1.0.0",
+      },
+    ],
+    changesets: [],
+  }).join("\n"),
+  /exceeds the configured release line 0\.x/u
+);
+
+assert.deepEqual(
+  validateReleaseVersionContract({
+    maximumPublishedMajor: 1,
+    packages,
+    changesets: [changeset("major")],
+  }),
+  []
+);
+
+process.stdout.write(
+  "Release version contract rejected explicit and generated stable-major fixtures\n"
+);

--- a/scripts/test-release-version-contract.mjs
+++ b/scripts/test-release-version-contract.mjs
@@ -22,6 +22,17 @@ Fixture release.
 `,
   }),
 });
+const validatePackageVersion = version =>
+  validateReleaseVersionContract({
+    maximumPublishedMajor: 0,
+    packages: [
+      {
+        name: "@rexeus/typeweaver",
+        version,
+      },
+    ],
+    changesets: [],
+  });
 
 assert.deepEqual(
   validateReleaseVersionContract({
@@ -42,18 +53,26 @@ assert.match(
 );
 
 assert.match(
-  validateReleaseVersionContract({
-    maximumPublishedMajor: 0,
-    packages: [
-      {
-        name: "@rexeus/typeweaver",
-        version: "1.0.0",
-      },
-    ],
-    changesets: [],
-  }).join("\n"),
+  validatePackageVersion("1.0.0").join("\n"),
   /exceeds the configured release line 0\.x/u
 );
+
+for (const invalidVersion of [
+  "0.12.0-",
+  "0.12.0+",
+  "0.12.0-alpha..1",
+  "0.12.0+build..1",
+  "0.12.0+build_1",
+  "0.12.0-01",
+]) {
+  assert.match(
+    validatePackageVersion(invalidVersion).join("\n"),
+    /has an invalid semantic version/u,
+    `${invalidVersion} must be rejected`
+  );
+}
+
+assert.deepEqual(validatePackageVersion("0.12.0-alpha.1+build.007"), []);
 
 assert.deepEqual(
   validateReleaseVersionContract({

--- a/scripts/verify-architecture-contracts.mjs
+++ b/scripts/verify-architecture-contracts.mjs
@@ -59,6 +59,10 @@ const commands = [
     args: ["run", "verify:effect-version"],
   },
   {
+    label: "Pre-1.0 release version contract",
+    args: ["run", "verify:release-version"],
+  },
+  {
     label: "Documentation link integrity",
     args: ["run", "docs:check"],
   },


### PR DESCRIPTION
## Summary

- Change the Effect migration changeset from an explicit major bump to a minor bump, making 0.13.0 the next coordinated package release.
- Update the migration guide and plugin authoring examples to use the 0.13 release line.
- Add a repository release policy and CI contract that reject both pending major changesets and generated package versions above the configured 0.x line.
- Document how the pre-1.0 policy relates to the existing Changesets patch.

## Root cause

The patch for @changesets/assemble-release-plan prevents major bumps propagated through peer dependencies. It intentionally does not override an explicit major entry in Changesets frontmatter. The Effect migration changeset contained explicit major entries, so Changesets correctly generated 1.0.0 despite the patch.

## Verification

- pnpm verify:release-version
- pnpm changeset status
- pnpm format:check
- pnpm lint
- pnpm verify:architecture-contracts
- A full Changesets version simulation produced exactly 11 published packages at 0.13.0, consumed the migration changeset, updated every package changelog, and passed the release-version and documentation contracts in the generated state.

## Review focus

- The policy boundary in config/release-policy.json and ADR 0009
- Rejection behavior for source changesets and generated release pull requests
- 0.13 migration documentation and package examples

## Release coordination

The existing release PR #205 must not be merged in its current 1.0.0 form. After this PR merges, the Changesets automation should regenerate or update that release PR for 0.13.0, and its checks must pass before merge.